### PR TITLE
perf: add React.memo and useCallback optimizations

### DIFF
--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import React, { useState } from 'react';
 import { ChannelRecommendation } from '@/types/recommendation';
-import { useState } from 'react';
 
 const typeColors: Record<string, string> = {
   social: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
@@ -23,7 +23,7 @@ const costColors: Record<string, string> = {
   medium: 'bg-orange-500/20 text-orange-300',
 };
 
-export default function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation }) {
+function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation }) {
   const { channel, relevanceScore, reason, actionItems } = recommendation;
   const [checkedItems, setCheckedItems] = useState<Record<number, boolean>>({});
 
@@ -135,3 +135,5 @@ export default function ChannelCard({ recommendation }: { recommendation: Channe
     </div>
   );
 }
+
+export default React.memo(ChannelCard);

--- a/src/components/ChannelList.tsx
+++ b/src/components/ChannelList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { ChannelRecommendation } from '@/types/recommendation';
 import ChannelCard from './ChannelCard';
 
@@ -21,6 +21,14 @@ const tabs: { value: ChannelType; label: string }[] = [
 export default function ChannelList({ recommendations }: { recommendations: ChannelRecommendation[] }) {
   const [activeType, setActiveType] = useState<ChannelType>('all');
   const [sortBy, setSortBy] = useState<SortOption>('relevance');
+
+  const handleTypeChange = useCallback((type: ChannelType) => {
+    setActiveType(type);
+  }, []);
+
+  const handleSortChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSortBy(e.target.value as SortOption);
+  }, []);
 
   const filtered = useMemo(() => {
     let result = recommendations;
@@ -48,7 +56,7 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
           {tabs.map((tab) => (
             <button
               key={tab.value}
-              onClick={() => setActiveType(tab.value)}
+              onClick={() => handleTypeChange(tab.value)}
               className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
                 activeType === tab.value
                   ? 'bg-white/15 text-white shadow-sm'
@@ -65,7 +73,7 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
           <span className="text-sm text-white/40">Sort by</span>
           <select
             value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as SortOption)}
+            onChange={handleSortChange}
             className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/70 backdrop-blur-md outline-none transition-colors focus:border-white/20"
           >
             <option value="relevance">Relevance</option>

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   type ExportData,
   exportToMarkdown,
@@ -15,7 +15,7 @@ interface ExportPanelProps {
   data: ExportData;
 }
 
-export default function ExportPanel({ data }: ExportPanelProps) {
+function ExportPanel({ data }: ExportPanelProps) {
   const [markdownCopyState, setMarkdownCopyState] = useState<CopyState>('idle');
   const [linkCopyState, setLinkCopyState] = useState<CopyState>('idle');
 
@@ -115,6 +115,8 @@ export default function ExportPanel({ data }: ExportPanelProps) {
     </div>
   );
 }
+
+export default React.memo(ExportPanel);
 
 /* ---------- Inline SVG icons ---------- */
 


### PR DESCRIPTION
## Summary
- Wrap `ChannelCard` with `React.memo()` to skip re-renders when props haven't changed
- Wrap `ExportPanel` with `React.memo()` to prevent unnecessary re-renders from parent
- Add `useCallback` for filter type and sort change handlers in `ChannelList`

Closes #41

## Test plan
- [x] `pnpm build` compiles without errors
- [x] All 12 existing tests pass (`pnpm test`)
- [ ] Manual verification: filter/sort in ChannelList still works correctly
- [ ] Manual verification: ExportPanel copy/download buttons still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)