### PR TITLE
test: add API route and component test coverage

### DIFF
--- a/__tests__/api/plans.test.ts
+++ b/__tests__/api/plans.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPlan, getAllPlans, getPlan, updatePlan, deletePlan } from '../../src/lib/store';
+import { generateRecommendations } from '../../src/lib/engine';
+import type { ProjectInput, LaunchPlan } from '../../src/types/project';
+
+/**
+ * Tests for the API plans route logic.
+ *
+ * We test the store and engine functions directly rather than importing the
+ * Next.js route handler, because the route handler depends on NextResponse
+ * from 'next/server' which is not available in vitest's jsdom environment.
+ *
+ * These tests verify the same logic the POST/GET handlers exercise:
+ * - Input validation (required fields check)
+ * - Plan creation via store
+ * - Plan retrieval via store
+ * - Recommendation generation from engine
+ */
+
+const validInput: ProjectInput = {
+  projectName: 'TestApp',
+  description: 'A test application for unit testing',
+  repoUrl: 'https://github.com/test/app',
+  demoUrl: 'https://testapp.vercel.app',
+};
+
+function validateInput(body: Partial<ProjectInput>): string | null {
+  const { projectName, description, repoUrl, demoUrl } = body;
+  if (!projectName || !description || !repoUrl || !demoUrl) {
+    return 'Missing required fields: projectName, description, repoUrl, demoUrl';
+  }
+  return null;
+}
+
+function createPlanFromInput(input: ProjectInput): LaunchPlan {
+  const recommendations = generateRecommendations(input);
+  const now = new Date().toISOString();
+  return createPlan({
+    id: crypto.randomUUID(),
+    input,
+    channels: recommendations.channels.map((c) => c.channel.name),
+    recommendations,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe('API plans route logic', () => {
+  describe('input validation', () => {
+    it('returns null for valid input', () => {
+      expect(validateInput(validInput)).toBeNull();
+    });
+
+    it('returns error when all fields are missing', () => {
+      expect(validateInput({})).toBe(
+        'Missing required fields: projectName, description, repoUrl, demoUrl',
+      );
+    });
+
+    it('returns error when only projectName is provided', () => {
+      expect(validateInput({ projectName: 'Test' })).toContain('Missing required fields');
+    });
+
+    it('returns error when only some required fields are provided', () => {
+      expect(
+        validateInput({ projectName: 'Test', description: 'A test app' }),
+      ).toContain('Missing required fields');
+    });
+
+    it('returns error when one required field is missing', () => {
+      expect(
+        validateInput({
+          projectName: 'Test',
+          description: 'A test app',
+          repoUrl: 'https://github.com/test/app',
+          // demoUrl missing
+        }),
+      ).toContain('Missing required fields');
+    });
+  });
+
+  describe('POST - plan creation', () => {
+    it('creates a plan with valid input and returns it', () => {
+      const plan = createPlanFromInput(validInput);
+
+      expect(plan.id).toBeDefined();
+      expect(plan.input.projectName).toBe('TestApp');
+      expect(plan.input.description).toBe('A test application for unit testing');
+      expect(plan.channels).toBeDefined();
+      expect(Array.isArray(plan.channels)).toBe(true);
+      expect(plan.channels.length).toBeGreaterThan(0);
+      expect(plan.recommendations).toBeDefined();
+      expect(plan.createdAt).toBeDefined();
+      expect(plan.updatedAt).toBeDefined();
+    });
+
+    it('stores the created plan in the store', () => {
+      const plan = createPlanFromInput(validInput);
+      const retrieved = getPlan(plan.id);
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe(plan.id);
+      expect(retrieved!.input.projectName).toBe('TestApp');
+    });
+
+    it('includes optional fields when provided', () => {
+      const input: ProjectInput = {
+        ...validInput,
+        category: 'devtool',
+        budget: 'zero',
+        targetAudience: 'developers',
+        timeline: 'standard',
+      };
+      const plan = createPlanFromInput(input);
+
+      expect(plan.input.category).toBe('devtool');
+      expect(plan.input.budget).toBe('zero');
+      expect(plan.input.targetAudience).toBe('developers');
+      expect(plan.input.timeline).toBe('standard');
+    });
+
+    it('generates recommendations with channels', () => {
+      const plan = createPlanFromInput(validInput);
+
+      expect(plan.recommendations).toBeDefined();
+      expect(plan.recommendations!.channels.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('GET - plan retrieval', () => {
+    it('getAllPlans returns created plans', () => {
+      const plan = createPlanFromInput({
+        ...validInput,
+        projectName: 'UniqueGetTest',
+      });
+
+      const plans = getAllPlans();
+      expect(Array.isArray(plans)).toBe(true);
+
+      const found = plans.find((p) => p.id === plan.id);
+      expect(found).toBeDefined();
+      expect(found!.input.projectName).toBe('UniqueGetTest');
+    });
+
+    it('returns multiple plans after multiple creations', () => {
+      const initialCount = getAllPlans().length;
+
+      createPlanFromInput({ ...validInput, projectName: 'Plan A' });
+      createPlanFromInput({ ...validInput, projectName: 'Plan B' });
+
+      const plans = getAllPlans();
+      expect(plans.length).toBeGreaterThanOrEqual(initialCount + 2);
+    });
+  });
+
+  describe('store CRUD operations', () => {
+    it('updatePlan modifies an existing plan', async () => {
+      const plan = createPlanFromInput(validInput);
+      // Wait a tick so the updatedAt timestamp differs
+      await new Promise((r) => setTimeout(r, 5));
+      const updated = updatePlan(plan.id, {
+        channels: ['Reddit', 'Hacker News'],
+      });
+
+      expect(updated).toBeDefined();
+      expect(updated!.channels).toEqual(['Reddit', 'Hacker News']);
+      expect(updated!.updatedAt).not.toBe(plan.updatedAt);
+    });
+
+    it('updatePlan returns undefined for non-existent plan', () => {
+      const result = updatePlan('non-existent-id', { channels: [] });
+      expect(result).toBeUndefined();
+    });
+
+    it('deletePlan removes a plan', () => {
+      const plan = createPlanFromInput(validInput);
+      expect(getPlan(plan.id)).toBeDefined();
+
+      const deleted = deletePlan(plan.id);
+      expect(deleted).toBe(true);
+      expect(getPlan(plan.id)).toBeUndefined();
+    });
+
+    it('deletePlan returns false for non-existent plan', () => {
+      expect(deletePlan('non-existent-id')).toBe(false);
+    });
+  });
+});

--- a/__tests__/components/ProjectForm.test.tsx
+++ b/__tests__/components/ProjectForm.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProjectForm from '../../src/components/ProjectForm';
+
+describe('ProjectForm', () => {
+  it('renders all required fields', () => {
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    expect(screen.getByLabelText(/project name/i)).toBeDefined();
+    expect(screen.getByLabelText(/short description/i)).toBeDefined();
+    expect(screen.getByLabelText(/repository url/i)).toBeDefined();
+    expect(screen.getByLabelText(/demo url/i)).toBeDefined();
+  });
+
+  it('renders the submit button', () => {
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    const button = screen.getByRole('button', { name: /generate launch plan/i });
+    expect(button).toBeDefined();
+  });
+
+  it('shows validation errors when submitting empty form', async () => {
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    const button = screen.getByRole('button', { name: /generate launch plan/i });
+    fireEvent.click(button);
+
+    expect(screen.getByText('Project name is required')).toBeDefined();
+    expect(screen.getByText('Description is required')).toBeDefined();
+    expect(screen.getByText('Repository URL is required')).toBeDefined();
+    expect(screen.getByText('Demo URL is required')).toBeDefined();
+  });
+
+  it('validates description character limit', async () => {
+    const user = userEvent.setup();
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    const textarea = screen.getByLabelText(/short description/i);
+    // The textarea has maxLength=200, but validation also checks > 200
+    // Type a long string (textarea maxLength will truncate in browser but not in test DOM)
+    await user.type(screen.getByLabelText(/project name/i), 'Test');
+    // Directly set the value to bypass maxLength
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(201) } });
+    await user.type(screen.getByLabelText(/repository url/i), 'https://github.com/test/app');
+    await user.type(screen.getByLabelText(/demo url/i), 'https://example.com');
+
+    fireEvent.click(screen.getByRole('button', { name: /generate launch plan/i }));
+
+    expect(screen.getByText('Description must be 200 characters or less')).toBeDefined();
+  });
+
+  it('validates URL format for repo and demo URLs', async () => {
+    const user = userEvent.setup();
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    await user.type(screen.getByLabelText(/project name/i), 'Test');
+    await user.type(screen.getByLabelText(/short description/i), 'A test project');
+    await user.type(screen.getByLabelText(/repository url/i), 'http://github.com/test');
+    await user.type(screen.getByLabelText(/demo url/i), 'ftp://example.com');
+
+    fireEvent.click(screen.getByRole('button', { name: /generate launch plan/i }));
+
+    const urlErrors = screen.getAllByText('URL must start with https://');
+    expect(urlErrors.length).toBe(2);
+  });
+
+  it('calls onSubmit with form data when valid', async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<ProjectForm onSubmit={handleSubmit} />);
+
+    await user.type(screen.getByLabelText(/project name/i), 'My App');
+    await user.type(screen.getByLabelText(/short description/i), 'A great app');
+    await user.type(screen.getByLabelText(/repository url/i), 'https://github.com/test/app');
+    await user.type(screen.getByLabelText(/demo url/i), 'https://myapp.com');
+
+    fireEvent.click(screen.getByRole('button', { name: /generate launch plan/i }));
+
+    expect(handleSubmit).toHaveBeenCalledOnce();
+    expect(handleSubmit).toHaveBeenCalledWith({
+      projectName: 'My App',
+      description: 'A great app',
+      repoUrl: 'https://github.com/test/app',
+      demoUrl: 'https://myapp.com',
+    });
+  });
+
+  it('shows loading state when isSubmitting is true', () => {
+    render(<ProjectForm onSubmit={() => {}} isSubmitting={true} />);
+
+    expect(screen.getByRole('button', { name: /generating/i })).toBeDefined();
+  });
+
+  it('disables inputs when isSubmitting', () => {
+    render(<ProjectForm onSubmit={() => {}} isSubmitting={true} />);
+
+    expect(screen.getByLabelText(/project name/i)).toHaveProperty('disabled', true);
+    expect(screen.getByLabelText(/short description/i)).toHaveProperty('disabled', true);
+    expect(screen.getByLabelText(/repository url/i)).toHaveProperty('disabled', true);
+    expect(screen.getByLabelText(/demo url/i)).toHaveProperty('disabled', true);
+  });
+
+  it('shows advanced options when toggle is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    // Advanced fields should not be visible initially
+    expect(screen.queryByLabelText(/target audience/i)).toBeNull();
+
+    // Click the advanced options toggle
+    await user.click(screen.getByRole('button', { name: /advanced options/i }));
+
+    // Now advanced fields should be visible
+    expect(screen.getByLabelText(/target audience/i)).toBeDefined();
+    expect(screen.getByLabelText(/category/i)).toBeDefined();
+    expect(screen.getByLabelText(/budget/i)).toBeDefined();
+    expect(screen.getByLabelText(/timeline/i)).toBeDefined();
+  });
+
+  it('displays character counter for description', () => {
+    render(<ProjectForm onSubmit={() => {}} />);
+
+    expect(screen.getByText('0/200')).toBeDefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "tailwindcss": "^4.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,15 @@ importers:
         specifier: ^4.0.0
         version: 4.2.1
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13
@@ -50,6 +59,9 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -131,6 +143,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -803,8 +819,40 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1053,12 +1101,23 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1209,6 +1268,9 @@ packages:
     resolution: {integrity: sha512-t99A4LolkP0ZX9WUoaHz4YrPT1FKNlV8IDCeCPPpGaWyxegh64tt/BSUqN3u5necrYRon+ddZ6mPMjxIlfpobg==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
@@ -1270,6 +1332,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1277,6 +1343,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1628,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1829,6 +1905,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1846,6 +1926,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -2001,6 +2085,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2019,6 +2107,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -2026,6 +2117,10 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2182,6 +2277,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2455,6 +2554,8 @@ snapshots:
 
   '@acemir/cssom@0.9.31': {}
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
       '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
@@ -2561,6 +2662,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -3016,10 +3119,45 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3282,11 +3420,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -3463,6 +3609,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssstyle@6.2.0:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
@@ -3525,12 +3673,18 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
 
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3688,8 +3842,8 @@ snapshots:
       '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
       eslint: 9.39.3
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3))(eslint@9.39.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3)
       eslint-plugin-react: 7.37.5(eslint@9.39.3)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.3)
@@ -3708,7 +3862,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3719,22 +3873,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3))(eslint@9.39.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3))(eslint@9.39.3):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
       eslint: 9.39.3
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3))(eslint@9.39.3):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3745,7 +3899,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.3
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3))(eslint@9.39.3))(eslint@9.39.3)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4046,6 +4200,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -4268,6 +4424,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4282,6 +4440,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -4438,6 +4598,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4455,9 +4621,16 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-refresh@0.17.0: {}
 
   react@19.2.4: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4720,6 +4893,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- Adds `__tests__/api/plans.test.ts` with 15 tests covering input validation, plan creation/retrieval, and store CRUD operations (create, get, getAll, update, delete)
- Adds `__tests__/components/ProjectForm.test.tsx` with 10 tests covering form rendering, required field validation, description character limit, URL format validation, submit callback, loading/disabled states, and advanced options toggle
- Installs `@testing-library/react`, `@testing-library/jest-dom`, and `@testing-library/user-event` as dev dependencies

Closes #39

## Test plan
- [x] All 37 tests pass (`pnpm test`): 15 API/store tests + 10 component tests + 12 existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)