### PR TITLE
feat: add shareable launch plan URLs

### DIFF
--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -10,13 +10,32 @@ export default function LaunchPage() {
   const [, setProjectData] = useState<ProjectInput | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  function handleSubmit(data: ProjectInput) {
+  async function handleSubmit(data: ProjectInput) {
     setIsSubmitting(true);
     setProjectData(data);
-    // Store in sessionStorage so /results can read it
+
+    // Always store in sessionStorage as fallback
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('projectInput', JSON.stringify(data));
     }
+
+    // Try to persist via API for shareable URL
+    try {
+      const res = await fetch('/api/plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (res.ok) {
+        const plan = await res.json();
+        router.push(`/results?id=${plan.id}`);
+        return;
+      }
+    } catch {
+      // API failed — fall back to sessionStorage-only flow
+    }
+
     router.push('/results');
   }
 

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -1,34 +1,86 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import ChannelList from '@/components/ChannelList';
+import ExportPanel from '@/components/ExportPanel';
 import { generateRecommendations } from '@/lib/engine';
 import type { ProjectInput } from '@/types/project';
 import type { ChannelRecommendation } from '@/types/recommendation';
 
-export default function ResultsPage() {
+function ResultsContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const planId = searchParams.get('id');
+
   const [channels, setChannels] = useState<ChannelRecommendation[] | null>(null);
   const [projectName, setProjectName] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const raw = sessionStorage.getItem('projectInput');
-    if (!raw) {
-      router.push('/launch');
-      return;
+    async function loadPlan() {
+      // If we have a plan ID, fetch from API
+      if (planId) {
+        try {
+          const res = await fetch(`/api/plans/${planId}`);
+          if (res.ok) {
+            const plan = await res.json();
+            setProjectName(plan.input.projectName);
+            if (plan.recommendations?.channels) {
+              setChannels(plan.recommendations.channels);
+            } else {
+              // Regenerate from stored input if recommendations missing
+              const recs = generateRecommendations(plan.input);
+              setChannels(recs.channels);
+            }
+            return;
+          }
+          setError('Plan not found. It may have expired or been deleted.');
+          return;
+        } catch {
+          setError('Failed to load plan. Please try again.');
+          return;
+        }
+      }
+
+      // Fallback: load from sessionStorage (backward compat)
+      const raw = sessionStorage.getItem('projectInput');
+      if (!raw) {
+        router.push('/launch');
+        return;
+      }
+
+      try {
+        const input: ProjectInput = JSON.parse(raw);
+        setProjectName(input.projectName);
+        const plan = generateRecommendations(input);
+        setChannels(plan.channels);
+      } catch {
+        router.push('/launch');
+      }
     }
 
-    try {
-      const input: ProjectInput = JSON.parse(raw);
-      setProjectName(input.projectName);
-      const plan = generateRecommendations(input);
-      setChannels(plan.channels);
-    } catch {
-      router.push('/launch');
-    }
-  }, [router]);
+    loadPlan();
+  }, [router, planId]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center">
+        <div className="text-center">
+          <div className="mb-4 text-4xl">&#x26A0;</div>
+          <h2 className="text-xl font-semibold text-white mb-2">Plan Not Found</h2>
+          <p className="text-white/50 mb-6">{error}</p>
+          <Link
+            href="/launch"
+            className="inline-flex items-center gap-2 rounded-lg border border-white/20 bg-white/10 px-5 py-2.5 text-sm font-medium text-white transition-all hover:bg-white/20"
+          >
+            Create a new plan
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   if (!channels) {
     return (
@@ -65,7 +117,42 @@ export default function ResultsPage() {
 
         {/* Channel list */}
         <ChannelList recommendations={channels} />
+
+        {/* Export & Share */}
+        <div className="mt-10">
+          <ExportPanel
+            data={{
+              projectName,
+              channels: channels.map((c) => ({
+                name: c.channel.name,
+                url: c.channel.url,
+                reason: c.reason,
+                actionItems: c.actionItems,
+              })),
+              timeline: [],
+              templates: [],
+            }}
+            planId={planId ?? undefined}
+          />
+        </div>
       </div>
     </div>
+  );
+}
+
+export default function ResultsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center">
+          <div className="text-center">
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-white/20 border-t-white/80" />
+            <p className="mt-4 text-white/50">Loading...</p>
+          </div>
+        </div>
+      }
+    >
+      <ResultsContent />
+    </Suspense>
   );
 }

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -13,9 +13,10 @@ type CopyState = 'idle' | 'copied';
 
 interface ExportPanelProps {
   data: ExportData;
+  planId?: string;
 }
 
-function ExportPanel({ data }: ExportPanelProps) {
+function ExportPanel({ data, planId }: ExportPanelProps) {
   const [markdownCopyState, setMarkdownCopyState] = useState<CopyState>('idle');
   const [linkCopyState, setLinkCopyState] = useState<CopyState>('idle');
 
@@ -39,11 +40,13 @@ function ExportPanel({ data }: ExportPanelProps) {
   }, [data]);
 
   const handleCopyLink = useCallback(async () => {
-    // Placeholder: copy current URL for now; will be replaced with share URL
-    await copyToClipboard(window.location.href);
+    const shareUrl = planId
+      ? `${window.location.origin}/results?id=${planId}`
+      : window.location.href;
+    await copyToClipboard(shareUrl);
     setLinkCopyState('copied');
     setTimeout(() => setLinkCopyState('idle'), 2000);
-  }, []);
+  }, [planId]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Launch page now POSTs plan data to `/api/plans` and navigates to `/results?id={planId}`, with sessionStorage as fallback if the API call fails
- Results page checks for `id` query param and fetches the plan from `/api/plans/{id}`, falling back to sessionStorage for backward compatibility
- ExportPanel accepts a `planId` prop and generates proper shareable URLs (e.g., `/results?id=abc-123`) for the "Copy link" button
- Added error state when a shared plan is not found, and Suspense boundary for `useSearchParams()`

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] All 12 existing tests pass (`pnpm test`)
- [ ] Manual: submit a project form, verify URL updates to `/results?id=...`
- [ ] Manual: copy the shareable URL, open in a new tab/incognito, verify plan loads
- [ ] Manual: visit `/results?id=nonexistent`, verify error state renders
- [ ] Manual: clear sessionStorage, visit `/results` without `id`, verify redirect to `/launch`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)