### PR TITLE
feat: add outreach templates for Dev.to and Indie Hackers

### DIFF
--- a/__tests__/channels.test.ts
+++ b/__tests__/channels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CHANNELS as channels } from '../src/lib/channels';
+import { outreachTemplates } from '../src/lib/templates';
 
 describe('channels', () => {
   it('array is not empty', () => {
@@ -21,5 +22,37 @@ describe('channels', () => {
     channels.forEach(ch => {
       expect(ch.url).toMatch(/^https:\/\//);
     });
+  });
+
+  it('includes Dev.to channel', () => {
+    const devto = channels.find(ch => ch.name === 'Dev.to');
+    expect(devto).toBeDefined();
+    expect(devto!.url).toBe('https://dev.to/');
+    expect(devto!.type).toBe('community');
+  });
+
+  it('includes Indie Hackers channel', () => {
+    const ih = channels.find(ch => ch.name === 'Indie Hackers');
+    expect(ih).toBeDefined();
+    expect(ih!.url).toBe('https://www.indiehackers.com/');
+    expect(ih!.type).toBe('community');
+  });
+});
+
+describe('outreach templates', () => {
+  it('has a Dev.to template', () => {
+    const devtoTemplate = outreachTemplates.find(t => t.channelType === 'devto');
+    expect(devtoTemplate).toBeDefined();
+    expect(devtoTemplate!.channelName).toBe('Dev.to');
+    expect(devtoTemplate!.body).toContain('{{projectName}}');
+    expect(devtoTemplate!.tips.length).toBeGreaterThan(0);
+  });
+
+  it('has an Indie Hackers template', () => {
+    const ihTemplate = outreachTemplates.find(t => t.channelType === 'indiehackers');
+    expect(ihTemplate).toBeDefined();
+    expect(ihTemplate!.channelName).toBe('Indie Hackers');
+    expect(ihTemplate!.body).toContain('{{projectName}}');
+    expect(ihTemplate!.tips.length).toBeGreaterThan(0);
   });
 });

--- a/src/components/OutreachEditor.tsx
+++ b/src/components/OutreachEditor.tsx
@@ -11,6 +11,8 @@ const channelIcons: Record<OutreachTemplate['channelType'], string> = {
   linkedin: 'in',
   email: '@',
   community: '#',
+  devto: 'D',
+  indiehackers: 'IH',
 };
 
 interface OutreachEditorProps {

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -173,6 +173,107 @@ Best,
     ],
   },
   {
+    id: 'devto-article',
+    channelName: 'Dev.to',
+    channelType: 'devto',
+    subject: '{{projectName}} - {{description}}',
+    body: `---
+title: "I built {{projectName}} — {{description}}"
+published: true
+tags: showdev, webdev, opensource, productivity
+---
+
+I just launched **{{projectName}}** and wanted to share the journey with the Dev.to community.
+
+## The Problem
+
+[Describe the pain point you experienced firsthand]
+
+## The Solution
+
+{{projectName}} — {{description}}.
+
+## How It Works
+
+[Walk through the core architecture or workflow — include code snippets]
+
+\`\`\`typescript
+// Example usage
+\`\`\`
+
+## Tech Stack
+
+- [Framework]
+- [Database]
+- [Deployment]
+
+## Try It Out
+
+{{demoUrl}}
+
+## What's Next
+
+I'd love your feedback. What features would make this more useful? Drop a comment or open an issue.`,
+    tips: [
+      'DO: Write a genuine technical article, not a product pitch',
+      'DO: Include code snippets and architecture decisions',
+      'DO: Use relevant tags (#showdev is key for launches)',
+      'DO: Engage with comments — Dev.to rewards active authors',
+      "DON'T: Write a thin marketing post — Dev.to readers want depth",
+      "DON'T: Spam tags — stick to 4 relevant ones",
+      "DON'T: Skip the personal story — why you built it matters",
+      "DON'T: Forget to cross-post from your blog if you have one",
+    ],
+  },
+  {
+    id: 'indiehackers-post',
+    channelName: 'Indie Hackers',
+    channelType: 'indiehackers',
+    subject: '{{projectName}} — {{description}}',
+    body: `Hey IH!
+
+I just launched **{{projectName}}** — {{description}}.
+
+## The backstory
+
+[Share why you started building this — what problem were you facing?]
+
+## What I built
+
+{{projectName}} helps [target user] do [core value prop]. Here's a quick look: {{demoUrl}}
+
+## Key numbers
+
+- Time to build: [X weeks/months]
+- Tech stack: [brief]
+- Current users/signups: [be transparent]
+- Revenue: [even if $0 — IH respects honesty]
+
+## What worked for launch
+
+- [Tactic 1]
+- [Tactic 2]
+
+## What I'd do differently
+
+- [Lesson 1]
+- [Lesson 2]
+
+## Ask
+
+I'd love feedback from this community. What would make you use this? What's missing?`,
+    tips: [
+      'DO: Share real numbers — revenue, users, costs. IH loves transparency',
+      'DO: Focus on the journey and lessons, not just the product',
+      'DO: Engage in other IH discussions before and after posting',
+      'DO: Create a product page on IH to build long-term presence',
+      "DON'T: Write a press release — keep it conversational",
+      "DON'T: Hide behind vanity metrics — be honest about traction",
+      "DON'T: Post without engaging with the community first",
+      "DON'T: Ignore the milestone/group features — they drive visibility",
+    ],
+  },
+  {
     id: 'community-post',
     channelName: 'Community (Discord/Slack)',
     channelType: 'community',

--- a/src/types/outreach.ts
+++ b/src/types/outreach.ts
@@ -1,7 +1,7 @@
 export interface OutreachTemplate {
   id: string;
   channelName: string;
-  channelType: 'reddit' | 'hackernews' | 'producthunt' | 'twitter' | 'linkedin' | 'email' | 'community';
+  channelType: 'reddit' | 'hackernews' | 'producthunt' | 'twitter' | 'linkedin' | 'email' | 'community' | 'devto' | 'indiehackers';
   subject?: string;
   body: string;
   tips: string[];


### PR DESCRIPTION
## Summary
- Adds dedicated outreach templates for **Dev.to** (technical article with frontmatter, code snippets, tags) and **Indie Hackers** (launch post with metrics, journey, lessons learned)
- Adds `devto` and `indiehackers` channel types to the outreach type union
- Adds channel icons in OutreachEditor for both new types
- Adds dedicated tests verifying both channels exist and templates are properly configured

Closes #48, Closes #50

## Test plan
- [x] All 41 tests pass (`pnpm vitest run`)
- [ ] Verify Dev.to and Indie Hackers templates render correctly in the outreach workspace
- [ ] Verify template placeholders fill correctly with project data

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dev.to and Indie Hackers as new outreach channels, expanding your platform options for project promotion.
  * Both channels include pre-configured templates with subjects, customizable body content, and actionable tips to streamline outreach efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->