### PR TITLE
feat: add Indie Hackers outreach template and tests

### DIFF
--- a/__tests__/channels.test.ts
+++ b/__tests__/channels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CHANNELS as channels } from '../src/lib/channels';
+import { outreachTemplates } from '../src/lib/templates';
 
 describe('channels', () => {
   it('array is not empty', () => {
@@ -21,5 +22,25 @@ describe('channels', () => {
     channels.forEach(ch => {
       expect(ch.url).toMatch(/^https:\/\//);
     });
+  });
+
+  it('includes Indie Hackers channel', () => {
+    const ih = channels.find(ch => ch.name === 'Indie Hackers');
+    expect(ih).toBeDefined();
+    expect(ih!.type).toBe('community');
+    expect(ih!.url).toBe('https://www.indiehackers.com/');
+    expect(ih!.effort).toBe('medium');
+    expect(ih!.cost).toBe('free');
+  });
+});
+
+describe('outreach templates', () => {
+  it('includes Indie Hackers template', () => {
+    const ihTemplate = outreachTemplates.find(t => t.id === 'indiehackers-post');
+    expect(ihTemplate).toBeDefined();
+    expect(ihTemplate!.channelName).toBe('Indie Hackers');
+    expect(ihTemplate!.body).toContain('{{projectName}}');
+    expect(ihTemplate!.body).toContain('{{demoUrl}}');
+    expect(ihTemplate!.tips.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -173,6 +173,40 @@ Best,
     ],
   },
   {
+    id: 'indiehackers-post',
+    channelName: 'Indie Hackers',
+    channelType: 'community',
+    subject: '{{projectName}} - {{description}}',
+    body: `Hey IH!
+
+I just launched **{{projectName}}** - {{description}}.
+
+**Why I built this:** [What problem did you personally hit?]
+
+**How it works:** [1-2 sentence explanation]
+
+**Revenue/traction so far:** [Be transparent - even if it's $0]
+
+**Try it here:** {{demoUrl}}
+
+I'd love to hear:
+- Does this solve a real problem for you?
+- What would you charge for this (or would you pay for it)?
+- Any features you'd want before using it daily?
+
+Happy to share more about the build process, tech stack, or go-to-market strategy.`,
+    tips: [
+      'DO: Share real numbers - IH loves transparency about revenue and growth',
+      'DO: Explain your motivation and the problem you faced personally',
+      'DO: Engage in the comments and answer every question thoroughly',
+      'DO: Post in relevant groups (SaaS, Developer Tools, etc.)',
+      "DON'T: Write a generic launch post - IH values authenticity over polish",
+      "DON'T: Skip the business context - IH cares about viability, not just features",
+      "DON'T: Ignore follow-up questions - the community rewards engaged founders",
+      "DON'T: Spam multiple groups with the same post",
+    ],
+  },
+  {
     id: 'community-post',
     channelName: 'Community (Discord/Slack)',
     channelType: 'community',


### PR DESCRIPTION
## Summary
- Added Indie Hackers outreach template in `src/lib/templates.ts` with IH-specific post format and tips focused on transparency, revenue sharing, and authentic engagement
- Added tests in `__tests__/channels.test.ts` verifying the Indie Hackers channel entry and outreach template
- Channel entry already existed in `src/lib/channels.ts`

Closes #50

## Test plan
- [x] All 39 existing tests pass
- [x] New test verifies Indie Hackers channel exists with correct properties
- [x] New test verifies Indie Hackers outreach template has required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Indie Hackers outreach template enabling users to post projects to the community. The template includes a pre-configured subject line, post body with dynamic placeholders, and tips for maximizing engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->