### PR TITLE
feat: add Dev.to outreach template and channel tests

### DIFF
--- a/__tests__/channels.test.ts
+++ b/__tests__/channels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CHANNELS as channels } from '../src/lib/channels';
+import { outreachTemplates } from '../src/lib/templates';
 
 describe('channels', () => {
   it('array is not empty', () => {
@@ -20,6 +21,48 @@ describe('channels', () => {
   it('all URLs start with https://', () => {
     channels.forEach(ch => {
       expect(ch.url).toMatch(/^https:\/\//);
+    });
+  });
+
+  describe('Dev.to channel', () => {
+    const devto = channels.find(ch => ch.name === 'Dev.to');
+
+    it('exists in the channels list', () => {
+      expect(devto).toBeDefined();
+    });
+
+    it('has correct URL', () => {
+      expect(devto!.url).toBe('https://dev.to/');
+    });
+
+    it('is categorized as community type', () => {
+      expect(devto!.type).toBe('community');
+    });
+
+    it('has audience size and effort defined', () => {
+      expect(devto!.audienceSize).toBeTruthy();
+      expect(devto!.effort).toBeTruthy();
+    });
+  });
+
+  describe('Dev.to outreach template', () => {
+    const devtoTemplate = outreachTemplates.find(t => t.id === 'devto-post');
+
+    it('exists in the templates list', () => {
+      expect(devtoTemplate).toBeDefined();
+    });
+
+    it('has channelType set to devto', () => {
+      expect(devtoTemplate!.channelType).toBe('devto');
+    });
+
+    it('has a body with template placeholders', () => {
+      expect(devtoTemplate!.body).toContain('{{projectName}}');
+      expect(devtoTemplate!.body).toContain('{{demoUrl}}');
+    });
+
+    it('has tips array with entries', () => {
+      expect(devtoTemplate!.tips.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -145,6 +145,57 @@ If you know someone who could benefit from this, I'd appreciate a share.
     ],
   },
   {
+    id: 'devto-post',
+    channelName: 'Dev.to',
+    channelType: 'devto',
+    subject: '{{projectName}} - {{description}}',
+    body: `---
+title: "I built {{projectName}} — {{description}}"
+published: true
+tags: showdev, webdev, opensource, productivity
+---
+
+I just launched **{{projectName}}** and wanted to share it with the Dev.to community.
+
+## The Problem
+
+[Describe the pain point you experienced]
+
+## The Solution
+
+{{projectName}} — {{description}}.
+
+## How It Works
+
+[Walk through the core functionality with code snippets or screenshots]
+
+\`\`\`
+// Example usage or code snippet
+\`\`\`
+
+## Tech Stack
+
+- [Framework / Language]
+- [Database / Infrastructure]
+- [Notable libraries]
+
+## Try It Out
+
+Check it out here: {{demoUrl}}
+
+I'd love your feedback — what features would you want to see next?`,
+    tips: [
+      'DO: Use the #showdev tag to reach builders and early adopters',
+      'DO: Include code snippets, diagrams, or screenshots to make it engaging',
+      'DO: Write a genuine build story — Dev.to rewards authenticity',
+      'DO: Respond to every comment to boost visibility in the feed',
+      "DON'T: Write a pure marketing pitch — Dev.to readers want technical substance",
+      "DON'T: Skimp on formatting — use headers, lists, and code blocks",
+      "DON'T: Cross-post identical content without adding Dev.to-specific context",
+      "DON'T: Forget to add relevant tags (max 4 tags per post)",
+    ],
+  },
+  {
     id: 'cold-email',
     channelName: 'Cold Email',
     channelType: 'email',

--- a/src/types/outreach.ts
+++ b/src/types/outreach.ts
@@ -1,7 +1,7 @@
 export interface OutreachTemplate {
   id: string;
   channelName: string;
-  channelType: 'reddit' | 'hackernews' | 'producthunt' | 'twitter' | 'linkedin' | 'email' | 'community';
+  channelType: 'reddit' | 'hackernews' | 'producthunt' | 'twitter' | 'linkedin' | 'email' | 'community' | 'devto';
   subject?: string;
   body: string;
   tips: string[];


### PR DESCRIPTION
## Summary
- Added `'devto'` to the `channelType` union in `src/types/outreach.ts`
- Added a Dev.to outreach template in `src/lib/templates.ts` with blog post format, frontmatter, code snippet section, and actionable tips
- Added Dev.to-specific tests in `__tests__/channels.test.ts` covering channel entry and template validation

Closes #48

## Test plan
- [x] All 45 existing + new tests pass (`npx vitest run`)
- [ ] Verify Dev.to template renders correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dev.to as a new outreach channel option for community engagement. Users can now create and manage outreach campaigns specifically configured for the Dev.to platform, featuring pre-built templates with customizable subject lines, message bodies with intelligent placeholders, and comprehensive best practice tips to maximize campaign effectiveness and community reach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->