### PR TITLE
docs: add screenshot demos to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/hero-dark.png" alt="Automatic Launcher" width="720" />
+  <img src="docs/hero-dark.svg" alt="Automatic Launcher" width="720" />
 </p>
 
 <h1 align="center">Automatic Launcher</h1>
@@ -50,15 +50,15 @@ Open [http://localhost:3000](http://localhost:3000) and paste your project detai
 
 **Channel Recommendations** -- Get matched with the best launch channels for your project type. Reddit communities, Product Hunt, Hacker News, niche forums -- with direct links.
 
-<!-- ![Channel Recommendations](docs/screenshot-channels.png) -->
+![Channel Recommendations](docs/screenshot-channels.svg)
 
 **Outreach Playbooks** -- Ready-to-use post templates for each channel. Know exactly what to write, what tone to use, and how to frame your project.
 
-<!-- ![Outreach Playbooks](docs/screenshot-outreach.png) -->
+![Outreach Playbooks](docs/screenshot-outreach.svg)
 
 **24-Hour Launch Timeline** -- A structured plan broken into clear steps. Know exactly what to do and when, so you spend time launching instead of planning.
 
-<!-- ![Launch Timeline](docs/screenshot-timeline.png) -->
+![Launch Timeline](docs/screenshot-timeline.svg)
 
 ## How It Works
 

--- a/docs/hero-dark.svg
+++ b/docs/hero-dark.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600" width="1440" height="600">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#000000"/>
+      <stop offset="100%" style="stop-color:#0a0a0a"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1440" height="600" fill="url(#bg)"/>
+  <!-- Subtle grid -->
+  <g opacity="0.03" stroke="#ffffff" stroke-width="1">
+    <line x1="0" y1="100" x2="1440" y2="100"/>
+    <line x1="0" y1="200" x2="1440" y2="200"/>
+    <line x1="0" y1="300" x2="1440" y2="300"/>
+    <line x1="0" y1="400" x2="1440" y2="400"/>
+    <line x1="0" y1="500" x2="1440" y2="500"/>
+    <line x1="200" y1="0" x2="200" y2="600"/>
+    <line x1="400" y1="0" x2="400" y2="600"/>
+    <line x1="600" y1="0" x2="600" y2="600"/>
+    <line x1="800" y1="0" x2="800" y2="600"/>
+    <line x1="1000" y1="0" x2="1000" y2="600"/>
+    <line x1="1200" y1="0" x2="1200" y2="600"/>
+  </g>
+  <!-- Badge -->
+  <rect x="580" y="120" width="280" height="30" rx="15" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="720" y="140" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" letter-spacing="2" fill="#71717a" text-transform="uppercase">LAUNCH COPILOT FOR INDIE HACKERS</text>
+  <!-- Title -->
+  <text x="720" y="240" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="72" font-weight="700" fill="#ffffff" letter-spacing="-2">Launch Your Project</text>
+  <text x="720" y="320" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="72" font-weight="700" fill="#71717a" letter-spacing="-2">in 24 Hours</text>
+  <!-- Subtitle -->
+  <text x="720" y="380" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#71717a">Get an actionable launch plan tailored to your project.</text>
+  <text x="720" y="405" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#71717a">Personalized channel recommendations, outreach playbooks, and a step-by-step timeline.</text>
+  <!-- CTA Button -->
+  <rect x="590" y="450" width="260" height="52" rx="8" fill="#ffffff"/>
+  <text x="700" y="482" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#000000">Create Your Launch Plan  --></text>
+  <!-- Nav -->
+  <text x="100" y="45" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#ffffff">AUTOMATIC LAUNCHER</text>
+  <text x="1340" y="45" text-anchor="end" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#71717a">Launch</text>
+</svg>

--- a/docs/screenshot-channels.svg
+++ b/docs/screenshot-channels.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 700" width="1440" height="700">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#000000"/>
+      <stop offset="100%" style="stop-color:#0a0a0a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="700" fill="url(#bg)"/>
+  <!-- Back link -->
+  <text x="100" y="60" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#52525b">&lt; Back to launch</text>
+  <!-- Title -->
+  <text x="100" y="120" font-family="system-ui, -apple-system, sans-serif" font-size="48" font-weight="700" fill="#ffffff" letter-spacing="-1">Launch Plan for MyApp</text>
+  <text x="100" y="155" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#71717a">Personalized recommendations sorted by relevance to your project.</text>
+
+  <!-- Channel Card 1 -->
+  <rect x="80" y="190" width="620" height="210" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <circle cx="120" cy="230" r="16" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="148" y="236" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700" fill="#ffffff">r/SideProject</text>
+  <rect x="290" y="220" width="60" height="22" rx="11" fill="rgba(34,197,94,0.1)" stroke="rgba(34,197,94,0.2)" stroke-width="1"/>
+  <text x="320" y="235" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#22c55e">95%</text>
+  <text x="120" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Perfect for early-stage projects seeking feedback from fellow builders.</text>
+  <text x="120" y="295" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Active community of 250k+ indie hackers.</text>
+  <text x="120" y="330" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#a1a1aa">ACTION ITEMS</text>
+  <circle cx="128" cy="352" r="3" fill="#3f3f46"/>
+  <text x="140" y="356" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Write a Show /r/SideProject post with demo GIF</text>
+  <circle cx="128" cy="376" r="3" fill="#3f3f46"/>
+  <text x="140" y="380" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Include your tech stack and what makes it unique</text>
+
+  <!-- Channel Card 2 -->
+  <rect x="80" y="420" width="620" height="210" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <circle cx="120" cy="460" r="16" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="148" y="466" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700" fill="#ffffff">Hacker News</text>
+  <rect x="260" y="450" width="60" height="22" rx="11" fill="rgba(234,179,8,0.1)" stroke="rgba(234,179,8,0.2)" stroke-width="1"/>
+  <text x="290" y="465" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#eab308">82%</text>
+  <text x="120" y="500" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Show HN is ideal for developer tools and technical projects.</text>
+  <text x="120" y="525" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">High-quality traffic with strong conversion potential.</text>
+  <text x="120" y="560" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#a1a1aa">ACTION ITEMS</text>
+  <circle cx="128" cy="582" r="3" fill="#3f3f46"/>
+  <text x="140" y="586" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Submit as "Show HN: MyApp - brief description"</text>
+  <circle cx="128" cy="606" r="3" fill="#3f3f46"/>
+  <text x="140" y="610" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Post between 8-10am EST for maximum visibility</text>
+
+  <!-- Sidebar summary -->
+  <rect x="740" y="190" width="620" height="140" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="780" y="230" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">Plan Summary</text>
+  <text x="780" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">8 channels recommended</text>
+  <text x="780" y="285" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">24 action items total</text>
+  <text x="780" y="310" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Est. reach: 500k+ potential users</text>
+
+  <!-- Export button -->
+  <rect x="740" y="350" width="620" height="56" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="1050" y="384" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#a1a1aa">Export as Markdown  |  Copy Link  |  Share</text>
+</svg>

--- a/docs/screenshot-outreach.svg
+++ b/docs/screenshot-outreach.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600" width="1440" height="600">
+  <rect width="1440" height="600" fill="#000000"/>
+  <!-- Section title -->
+  <text x="100" y="60" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="#ffffff" letter-spacing="-0.5">Outreach Playbook</text>
+  <text x="100" y="90" font-family="system-ui, -apple-system, sans-serif" font-size="15" fill="#71717a">Ready-to-use templates tailored for each channel. Edit and customize before posting.</text>
+
+  <!-- Tab bar -->
+  <rect x="80" y="115" width="1280" height="44" rx="8" fill="rgba(255,255,255,0.02)"/>
+  <rect x="84" y="119" width="140" height="36" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <text x="154" y="142" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#ffffff">r/SideProject</text>
+  <text x="310" y="142" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#52525b">Hacker News</text>
+  <text x="460" y="142" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#52525b">Product Hunt</text>
+  <text x="600" y="142" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#52525b">Twitter/X</text>
+  <text x="730" y="142" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#52525b">Dev.to</text>
+
+  <!-- Editor area -->
+  <rect x="80" y="175" width="840" height="380" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <!-- Title field -->
+  <text x="120" y="215" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#52525b" letter-spacing="1">POST TITLE</text>
+  <rect x="120" y="228" width="760" height="40" rx="6" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="140" y="254" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#d4d4d8">I built MyApp - a tool that helps indie hackers launch faster</text>
+  <!-- Body field -->
+  <text x="120" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#52525b" letter-spacing="1">POST BODY</text>
+  <rect x="120" y="313" width="760" height="220" rx="6" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="140" y="343" font-family="monospace" font-size="13" fill="#a1a1aa">Hey everyone! I've been working on MyApp for the past</text>
+  <text x="140" y="367" font-family="monospace" font-size="13" fill="#a1a1aa">few months and just shipped v1.</text>
+  <text x="140" y="401" font-family="monospace" font-size="13" fill="#a1a1aa">**What it does:** Generates personalized launch plans</text>
+  <text x="140" y="425" font-family="monospace" font-size="13" fill="#a1a1aa">for indie hackers with channel recommendations and</text>
+  <text x="140" y="449" font-family="monospace" font-size="13" fill="#a1a1aa">outreach templates.</text>
+  <text x="140" y="483" font-family="monospace" font-size="13" fill="#a1a1aa">**Tech stack:** Next.js 15, React 19, Tailwind</text>
+  <text x="140" y="507" font-family="monospace" font-size="13" fill="#a1a1aa">Would love your feedback! [link]</text>
+
+  <!-- Tips sidebar -->
+  <rect x="960" y="175" width="400" height="380" rx="12" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="1000" y="215" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#ffffff">Tips for r/SideProject</text>
+  <circle cx="1008" cy="250" r="3" fill="#22c55e"/>
+  <text x="1020" y="255" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Be authentic, share your journey</text>
+  <circle cx="1008" cy="278" r="3" fill="#22c55e"/>
+  <text x="1020" y="283" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Include a demo GIF or screenshot</text>
+  <circle cx="1008" cy="306" r="3" fill="#22c55e"/>
+  <text x="1020" y="311" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Mention what problem you solved</text>
+  <circle cx="1008" cy="334" r="3" fill="#eab308"/>
+  <text x="1020" y="339" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Avoid overly promotional language</text>
+  <circle cx="1008" cy="362" r="3" fill="#eab308"/>
+  <text x="1020" y="367" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#a1a1aa">Engage with every comment</text>
+  <text x="1000" y="415" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#52525b" letter-spacing="1">BEST TIME TO POST</text>
+  <text x="1000" y="440" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#d4d4d8">Tuesday-Thursday, 9-11am EST</text>
+  <text x="1000" y="475" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#52525b" letter-spacing="1">EXPECTED ENGAGEMENT</text>
+  <text x="1000" y="500" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#d4d4d8">50-200 upvotes, 10-30 comments</text>
+</svg>

--- a/docs/screenshot-timeline.svg
+++ b/docs/screenshot-timeline.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 550" width="1440" height="550">
+  <rect width="1440" height="550" fill="#000000"/>
+  <!-- Section title -->
+  <text x="100" y="60" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="700" fill="#ffffff" letter-spacing="-0.5">24-Hour Launch Timeline</text>
+  <text x="100" y="90" font-family="system-ui, -apple-system, sans-serif" font-size="15" fill="#71717a">Step-by-step plan to maximize your launch day impact.</text>
+
+  <!-- Timeline line -->
+  <line x1="180" y1="130" x2="180" y2="510" stroke="rgba(255,255,255,0.06)" stroke-width="2"/>
+
+  <!-- Phase 1 -->
+  <circle cx="180" cy="155" r="8" fill="#22c55e" opacity="0.8"/>
+  <text x="210" y="148" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#22c55e" letter-spacing="1">8:00 AM - PRE-LAUNCH</text>
+  <rect x="210" y="160" width="1100" height="70" rx="10" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="240" y="185" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#d4d4d8">Final checks and preparation</text>
+  <text x="240" y="210" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Verify all links work  |  Prepare social media assets  |  Draft all posts  |  Set up analytics tracking</text>
+
+  <!-- Phase 2 -->
+  <circle cx="180" cy="270" r="8" fill="#3b82f6" opacity="0.8"/>
+  <text x="210" y="263" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#3b82f6" letter-spacing="1">10:00 AM - LAUNCH</text>
+  <rect x="210" y="275" width="1100" height="70" rx="10" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="240" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#d4d4d8">Go live on primary channels</text>
+  <text x="240" y="325" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Post to r/SideProject  |  Submit Show HN  |  Tweet launch thread  |  Notify your network</text>
+
+  <!-- Phase 3 -->
+  <circle cx="180" cy="385" r="8" fill="#eab308" opacity="0.8"/>
+  <text x="210" y="378" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#eab308" letter-spacing="1">2:00 PM - ENGAGE</text>
+  <rect x="210" y="390" width="1100" height="70" rx="10" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="240" y="415" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#d4d4d8">Monitor and respond to feedback</text>
+  <text x="240" y="440" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">Reply to every comment  |  Post to secondary channels  |  Share early traction updates  |  Fix any reported bugs</text>
+
+  <!-- Phase 4 -->
+  <circle cx="180" cy="500" r="8" fill="#a855f7" opacity="0.8"/>
+  <text x="210" y="493" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#a855f7" letter-spacing="1">8:00 PM - FOLLOW UP</text>
+  <rect x="210" y="505" width="1100" height="35" rx="10" fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+  <text x="240" y="528" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#d4d4d8">Review metrics, plan tomorrow's follow-up posts, thank supporters</text>
+</svg>


### PR DESCRIPTION
## Summary
- Created 4 SVG mockup images in `docs/` matching the app's dark minimalist aesthetic:
  - `hero-dark.svg` — landing page hero banner
  - `screenshot-channels.svg` — channel recommendations output
  - `screenshot-outreach.svg` — outreach playbook editor
  - `screenshot-timeline.svg` — 24-hour launch timeline
- Updated README.md to uncomment image placeholders and link to the new SVGs

Closes #53

## Test plan
- [x] All 37 existing tests pass
- [ ] Verify SVG images render correctly on GitHub README
- [ ] Check images display properly at different viewport widths

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with visual assets: enhanced hero image and product screenshots for Channel Recommendations, Outreach Playbooks, and Launch Timeline. Improved visual documentation for clearer feature understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->