### PR TITLE
feat: add dark/light theme toggle

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -14,7 +14,7 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center px-4">
       <div className="glass max-w-md w-full rounded-2xl p-8 text-center">
         <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10 border border-red-500/20">
           <svg
@@ -32,10 +32,10 @@ export default function GlobalError({
           </svg>
         </div>
 
-        <h1 className="text-2xl font-bold text-white mb-2">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">
           Something went wrong
         </h1>
-        <p className="text-white/50 mb-8">
+        <p className="text-[var(--text-muted)] mb-8">
           An unexpected error occurred. Please try again.
         </p>
 
@@ -45,7 +45,7 @@ export default function GlobalError({
               {error.message}
             </p>
             {error.digest && (
-              <p className="mt-2 text-xs text-white/30">
+              <p className="mt-2 text-xs text-[var(--text-faint)]">
                 Digest: {error.digest}
               </p>
             )}
@@ -54,7 +54,7 @@ export default function GlobalError({
 
         <button
           onClick={reset}
-          className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-6 py-3 text-sm font-medium text-white transition-all duration-300 hover:bg-white/20 border border-white/10 hover:border-white/20"
+          className="inline-flex items-center gap-2 rounded-xl bg-[var(--surface-8)] px-6 py-3 text-sm font-medium text-[var(--text-primary)] transition-all duration-300 hover:bg-[var(--surface-6)] border border-[var(--border-medium)] hover:border-[var(--border-hover)]"
         >
           <svg
             className="h-4 w-4"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,18 +1,80 @@
 @import "tailwindcss";
 
+:root {
+  --bg-page: #000000;
+  --surface-2: rgba(255, 255, 255, 0.02);
+  --surface-3: rgba(255, 255, 255, 0.03);
+  --surface-4: rgba(255, 255, 255, 0.04);
+  --surface-6: rgba(255, 255, 255, 0.06);
+  --surface-8: rgba(255, 255, 255, 0.08);
+  --text-primary: #ffffff;
+  --text-secondary: #a1a1aa;
+  --text-tertiary: #71717a;
+  --text-muted: #52525b;
+  --text-faint: #3f3f46;
+  --border-subtle: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.06);
+  --border-medium: rgba(255, 255, 255, 0.08);
+  --border-hover: rgba(255, 255, 255, 0.12);
+  --border-focus: rgba(255, 255, 255, 0.2);
+  --accent-bg: #ffffff;
+  --accent-text: #000000;
+  --accent-hover: #e4e4e7;
+  --progress-fill: rgba(255, 255, 255, 0.3);
+  --scrollbar-thumb: rgba(255, 255, 255, 0.08);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.15);
+  --ring-focus: rgba(255, 255, 255, 0.1);
+  --placeholder: #52525b;
+}
+
+[data-theme="light"] {
+  --bg-page: #f9fafb;
+  --surface-2: rgba(255, 255, 255, 0.8);
+  --surface-3: rgba(255, 255, 255, 0.7);
+  --surface-4: rgba(0, 0, 0, 0.03);
+  --surface-6: rgba(0, 0, 0, 0.05);
+  --surface-8: rgba(0, 0, 0, 0.08);
+  --text-primary: #18181b;
+  --text-secondary: #52525b;
+  --text-tertiary: #71717a;
+  --text-muted: #a1a1aa;
+  --text-faint: #d4d4d8;
+  --border-subtle: rgba(0, 0, 0, 0.06);
+  --border: rgba(0, 0, 0, 0.08);
+  --border-medium: rgba(0, 0, 0, 0.12);
+  --border-hover: rgba(0, 0, 0, 0.18);
+  --border-focus: rgba(0, 0, 0, 0.3);
+  --accent-bg: #18181b;
+  --accent-text: #ffffff;
+  --accent-hover: #27272a;
+  --progress-fill: rgba(0, 0, 0, 0.2);
+  --scrollbar-thumb: rgba(0, 0, 0, 0.1);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.2);
+  --ring-focus: rgba(0, 0, 0, 0.1);
+  --placeholder: #a1a1aa;
+}
+
 @layer base {
   body {
-    @apply bg-black text-zinc-100 antialiased;
+    background-color: var(--bg-page);
+    color: var(--text-secondary);
+    @apply antialiased;
   }
 }
 
 @layer utilities {
   .glass {
-    @apply bg-white/[0.03] backdrop-blur-xl border border-white/[0.06];
+    background-color: var(--surface-3);
+    backdrop-filter: blur(24px);
+    border: 1px solid var(--border);
   }
 
   .glass-hover {
-    @apply hover:bg-white/[0.06] hover:border-white/[0.12] transition-all duration-300;
+    @apply transition-all duration-300;
+  }
+  .glass-hover:hover {
+    background-color: var(--surface-6);
+    border-color: var(--border-hover);
   }
 }
 
@@ -23,9 +85,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--scrollbar-thumb);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--scrollbar-thumb-hover);
 }

--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -40,7 +40,7 @@ export default function LaunchPage() {
   }
 
   return (
-    <main className="min-h-screen bg-black flex items-center justify-center px-4 py-16">
+    <main className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center px-4 py-16">
       <ProjectForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
     </main>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import ThemeToggle from "@/components/ThemeToggle";
 
 const geist = Geist({
   subsets: ["latin"],
@@ -42,8 +44,18 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`}>
-      <body className="min-h-screen bg-black font-[family-name:var(--font-body)]">
-        {children}
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var t=localStorage.getItem('theme');if(t==='light'){document.documentElement.setAttribute('data-theme','light')}})()`,
+          }}
+        />
+      </head>
+      <body className="min-h-screen bg-[var(--bg-page)] font-[family-name:var(--font-body)]">
+        <ThemeProvider>
+          <ThemeToggle />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,20 +2,20 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center px-4">
       <div className="glass max-w-md w-full rounded-2xl p-8 text-center">
-        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 border border-white/10">
-          <span className="text-3xl font-bold text-white/30">?</span>
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--surface-4)] border border-[var(--border-medium)]">
+          <span className="text-3xl font-bold text-[var(--text-faint)]">?</span>
         </div>
 
-        <h1 className="text-2xl font-bold text-white mb-2">Page not found</h1>
-        <p className="text-white/50 mb-8">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">Page not found</h1>
+        <p className="text-[var(--text-muted)] mb-8">
           The page you are looking for does not exist or has been moved.
         </p>
 
         <Link
           href="/"
-          className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-6 py-3 text-sm font-medium text-white transition-all duration-300 hover:bg-white/20 border border-white/10 hover:border-white/20"
+          className="inline-flex items-center gap-2 rounded-xl bg-[var(--surface-8)] px-6 py-3 text-sm font-medium text-[var(--text-primary)] transition-all duration-300 hover:bg-[var(--surface-6)] border border-[var(--border-medium)] hover:border-[var(--border-hover)]"
         >
           <svg
             className="h-4 w-4"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,15 @@
 export default function Home() {
   return (
-    <div className="min-h-screen flex flex-col bg-black">
+    <div className="min-h-screen flex flex-col bg-[var(--bg-page)]">
       {/* Nav */}
       <nav className="px-6 py-6">
         <div className="max-w-5xl mx-auto flex items-center justify-between">
-          <span className="text-sm font-bold tracking-widest text-white uppercase">
+          <span className="text-sm font-bold tracking-widest text-[var(--text-primary)] uppercase">
             Automatic Launcher
           </span>
           <a
             href="/launch"
-            className="text-sm text-zinc-500 transition-colors hover:text-zinc-300"
+            className="text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
           >
             Launch
           </a>
@@ -19,19 +19,19 @@ export default function Home() {
       {/* Hero Section */}
       <main className="flex-1 flex flex-col items-center justify-center px-4 py-24 sm:py-32">
         <div className="max-w-2xl w-full text-center">
-          <div className="inline-block px-3 py-1 mb-8 text-xs font-medium tracking-widest uppercase rounded-full bg-white/[0.04] text-zinc-500 border border-white/[0.06]">
+          <div className="inline-block px-3 py-1 mb-8 text-xs font-medium tracking-widest uppercase rounded-full bg-[var(--surface-4)] text-[var(--text-muted)] border border-[var(--border)]">
             Launch Copilot for Indie Hackers
           </div>
 
-          <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight text-white mb-6">
+          <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight text-[var(--text-primary)] mb-6">
             Launch Your Project
             <br />
-            <span className="text-zinc-500">
+            <span className="text-[var(--text-muted)]">
               in 24 Hours
             </span>
           </h1>
 
-          <p className="text-lg text-zinc-500 mb-12 max-w-lg mx-auto leading-relaxed">
+          <p className="text-lg text-[var(--text-secondary)] mb-12 max-w-lg mx-auto leading-relaxed">
             Get an actionable launch plan tailored to your project. Personalized
             channel recommendations, outreach playbooks, and a step-by-step
             timeline.
@@ -39,7 +39,7 @@ export default function Home() {
 
           <a
             href="/launch"
-            className="inline-flex items-center gap-2 px-8 py-4 rounded-lg bg-white text-black text-sm font-semibold transition-all duration-150 hover:bg-zinc-200 active:scale-[0.97]"
+            className="inline-flex items-center gap-2 px-8 py-4 rounded-lg bg-[var(--accent-bg)] text-[var(--accent-text)] text-sm font-semibold transition-all duration-150 hover:bg-[var(--accent-hover)] active:scale-[0.97]"
           >
             Create Your Launch Plan
             <svg
@@ -62,15 +62,15 @@ export default function Home() {
       {/* Features Section */}
       <section className="px-4 pb-24 sm:pb-32">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-2xl font-bold tracking-tight text-center text-white mb-16">
+          <h2 className="text-2xl font-bold tracking-tight text-center text-[var(--text-primary)] mb-16">
             Everything you need to launch
           </h2>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
             <div className="glass glass-hover rounded-xl p-6">
-              <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center mb-4">
+              <div className="w-10 h-10 rounded-lg bg-[var(--surface-4)] border border-[var(--border)] flex items-center justify-center mb-4">
                 <svg
-                  className="w-5 h-5 text-zinc-400"
+                  className="w-5 h-5 text-[var(--text-tertiary)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -83,10 +83,10 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-sm font-bold text-zinc-100 mb-2">
+              <h3 className="text-sm font-bold text-[var(--text-primary)] mb-2">
                 Channel Recommendations
               </h3>
-              <p className="text-sm text-zinc-600 leading-relaxed">
+              <p className="text-sm text-[var(--text-muted)] leading-relaxed">
                 Get matched with the best launch channels for your project type
                 &mdash; from Reddit communities to Product Hunt and niche forums.
                 Complete with direct links.
@@ -94,9 +94,9 @@ export default function Home() {
             </div>
 
             <div className="glass glass-hover rounded-xl p-6">
-              <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center mb-4">
+              <div className="w-10 h-10 rounded-lg bg-[var(--surface-4)] border border-[var(--border)] flex items-center justify-center mb-4">
                 <svg
-                  className="w-5 h-5 text-zinc-400"
+                  className="w-5 h-5 text-[var(--text-tertiary)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -109,10 +109,10 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-sm font-bold text-zinc-100 mb-2">
+              <h3 className="text-sm font-bold text-[var(--text-primary)] mb-2">
                 Outreach Playbooks
               </h3>
-              <p className="text-sm text-zinc-600 leading-relaxed">
+              <p className="text-sm text-[var(--text-muted)] leading-relaxed">
                 Ready-to-use templates for each channel. Know exactly what to
                 post, how to frame your project, and what tone resonates with
                 each community.
@@ -120,9 +120,9 @@ export default function Home() {
             </div>
 
             <div className="glass glass-hover rounded-xl p-6">
-              <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center mb-4">
+              <div className="w-10 h-10 rounded-lg bg-[var(--surface-4)] border border-[var(--border)] flex items-center justify-center mb-4">
                 <svg
-                  className="w-5 h-5 text-zinc-400"
+                  className="w-5 h-5 text-[var(--text-tertiary)]"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -135,10 +135,10 @@ export default function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-sm font-bold text-zinc-100 mb-2">
+              <h3 className="text-sm font-bold text-[var(--text-primary)] mb-2">
                 Launch Timeline
               </h3>
-              <p className="text-sm text-zinc-600 leading-relaxed">
+              <p className="text-sm text-[var(--text-muted)] leading-relaxed">
                 A structured 24-hour plan broken into clear steps. Know exactly
                 what to do and when, so you spend time launching instead of
                 planning.
@@ -149,9 +149,9 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-white/[0.04] px-4 py-10">
+      <footer className="border-t border-[var(--border-subtle)] px-4 py-10">
         <div className="max-w-5xl mx-auto flex items-center justify-center">
-          <p className="text-xs text-zinc-700">
+          <p className="text-xs text-[var(--text-faint)]">
             Automatic Launcher &mdash; ship faster, launch smarter.
           </p>
         </div>

--- a/src/app/results/error.tsx
+++ b/src/app/results/error.tsx
@@ -15,7 +15,7 @@ export default function ResultsError({
   }, [error]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center px-4">
+    <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center px-4">
       <div className="glass max-w-md w-full rounded-2xl p-8 text-center">
         <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10 border border-red-500/20">
           <svg
@@ -33,10 +33,10 @@ export default function ResultsError({
           </svg>
         </div>
 
-        <h1 className="text-2xl font-bold text-white mb-2">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">
           Failed to load your launch plan
         </h1>
-        <p className="text-white/50 mb-8">
+        <p className="text-[var(--text-muted)] mb-8">
           Something went wrong while generating your recommendations. Please try
           again or go back to update your project details.
         </p>
@@ -47,7 +47,7 @@ export default function ResultsError({
               {error.message}
             </p>
             {error.digest && (
-              <p className="mt-2 text-xs text-white/30">
+              <p className="mt-2 text-xs text-[var(--text-faint)]">
                 Digest: {error.digest}
               </p>
             )}
@@ -57,7 +57,7 @@ export default function ResultsError({
         <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
           <button
             onClick={reset}
-            className="inline-flex items-center gap-2 rounded-xl bg-white/10 px-6 py-3 text-sm font-medium text-white transition-all duration-300 hover:bg-white/20 border border-white/10 hover:border-white/20"
+            className="inline-flex items-center gap-2 rounded-xl bg-[var(--surface-8)] px-6 py-3 text-sm font-medium text-[var(--text-primary)] transition-all duration-300 hover:bg-[var(--surface-6)] border border-[var(--border-medium)] hover:border-[var(--border-hover)]"
           >
             <svg
               className="h-4 w-4"
@@ -77,7 +77,7 @@ export default function ResultsError({
 
           <Link
             href="/launch"
-            className="inline-flex items-center gap-2 rounded-xl bg-white/5 px-6 py-3 text-sm font-medium text-white/70 transition-all duration-300 hover:bg-white/10 hover:text-white border border-white/5 hover:border-white/10"
+            className="inline-flex items-center gap-2 rounded-xl bg-[var(--surface-4)] px-6 py-3 text-sm font-medium text-[var(--text-secondary)] transition-all duration-300 hover:bg-[var(--surface-8)] hover:text-[var(--text-primary)] border border-[var(--border-subtle)] hover:border-[var(--border-medium)]"
           >
             <svg
               className="h-4 w-4"

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -66,14 +66,14 @@ function ResultsContent() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center">
+      <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center">
         <div className="text-center">
           <div className="mb-4 text-4xl">&#x26A0;</div>
-          <h2 className="text-xl font-semibold text-white mb-2">Plan Not Found</h2>
-          <p className="text-white/50 mb-6">{error}</p>
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">Plan Not Found</h2>
+          <p className="text-[var(--text-muted)] mb-6">{error}</p>
           <Link
             href="/launch"
-            className="inline-flex items-center gap-2 rounded-lg border border-white/20 bg-white/10 px-5 py-2.5 text-sm font-medium text-white transition-all hover:bg-white/20"
+            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border-hover)] bg-[var(--surface-8)] px-5 py-2.5 text-sm font-medium text-[var(--text-primary)] transition-all hover:bg-[var(--surface-6)]"
           >
             Create a new plan
           </Link>
@@ -84,33 +84,33 @@ function ResultsContent() {
 
   if (!channels) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center">
+      <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center">
         <div className="text-center">
-          <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-white/20 border-t-white/80" />
-          <p className="mt-4 text-white/50">Generating your launch plan...</p>
+          <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-[var(--border-hover)] border-t-[var(--text-primary)]" />
+          <p className="mt-4 text-[var(--text-muted)]">Generating your launch plan...</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black">
+    <div className="min-h-screen bg-[var(--bg-page)]">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-10">
           <Link
             href="/launch"
-            className="mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-600 transition-colors hover:text-zinc-400"
+            className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text-tertiary)]"
           >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back to launch
           </Link>
-          <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-[var(--text-primary)] sm:text-5xl">
             Launch Plan for {projectName}
           </h1>
-          <p className="mt-3 text-lg text-zinc-500">
+          <p className="mt-3 text-lg text-[var(--text-secondary)]">
             Personalized recommendations sorted by relevance to your project.
           </p>
         </div>
@@ -144,10 +144,10 @@ export default function ResultsPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-purple-950 flex items-center justify-center">
+        <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center">
           <div className="text-center">
-            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-white/20 border-t-white/80" />
-            <p className="mt-4 text-white/50">Loading...</p>
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-[var(--border-hover)] border-t-[var(--text-primary)]" />
+            <p className="mt-4 text-[var(--text-muted)]">Loading...</p>
           </div>
         </div>
       }

--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -14,7 +14,7 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
   const scorePercent = Math.round(relevanceScore * 100);
 
   return (
-    <div role="article" className="group relative rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-300 hover:border-white/[0.12] hover:bg-white/[0.04]">
+    <div role="article" className="group relative rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-6 transition-all duration-300 hover:border-[var(--border-hover)] hover:bg-[var(--surface-4)]">
       {/* Header */}
       <div className="mb-4 flex items-start justify-between gap-3">
         <a
@@ -22,11 +22,11 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`${channel.name} (opens in new tab)`}
-          className="flex items-center gap-2 text-sm font-bold text-zinc-100 transition-colors hover:text-white"
+          className="flex items-center gap-2 text-sm font-bold text-[var(--text-primary)] transition-colors hover:text-[var(--text-primary)]"
         >
           {channel.name}
           <svg
-            className="h-3.5 w-3.5 shrink-0 text-zinc-600 transition-colors group-hover:text-zinc-400"
+            className="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)] transition-colors group-hover:text-[var(--text-tertiary)]"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -41,7 +41,7 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
           </svg>
           <span className="sr-only">(opens in new tab)</span>
         </a>
-        <span className="shrink-0 rounded-full border border-white/[0.08] bg-white/[0.04] px-2.5 py-0.5 text-[11px] font-medium text-zinc-500">
+        <span className="shrink-0 rounded-full border border-[var(--border-medium)] bg-[var(--surface-4)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--text-muted)]">
           {channel.type}
         </span>
       </div>
@@ -49,42 +49,42 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
       {/* Relevance score bar */}
       <div className="mb-4">
         <div className="mb-1 flex items-center justify-between text-xs">
-          <span className="text-zinc-600">Relevance</span>
-          <span className="font-medium font-[family-name:var(--font-code)] text-zinc-500">{scorePercent}%</span>
+          <span className="text-[var(--text-muted)]">Relevance</span>
+          <span className="font-medium font-[family-name:var(--font-code)] text-[var(--text-secondary)]">{scorePercent}%</span>
         </div>
-        <div className="h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+        <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--surface-6)]">
           <div
-            className="h-full rounded-full bg-white/30 transition-all duration-500"
+            className="h-full rounded-full bg-[var(--progress-fill)] transition-all duration-500"
             style={{ width: `${scorePercent}%` }}
           />
         </div>
       </div>
 
       {/* Description */}
-      <p className="mb-4 text-sm leading-relaxed text-zinc-500">{channel.description}</p>
+      <p className="mb-4 text-sm leading-relaxed text-[var(--text-secondary)]">{channel.description}</p>
 
       {/* Badges */}
       <div className="mb-4 flex flex-wrap gap-2">
-        <span className="rounded-full bg-white/[0.04] border border-white/[0.06] px-2.5 py-0.5 text-[11px] text-zinc-500">
+        <span className="rounded-full bg-[var(--surface-4)] border border-[var(--border)] px-2.5 py-0.5 text-[11px] text-[var(--text-muted)]">
           {channel.audienceSize}
         </span>
-        <span className="rounded-full bg-white/[0.04] border border-white/[0.06] px-2.5 py-0.5 text-[11px] text-zinc-500">
+        <span className="rounded-full bg-[var(--surface-4)] border border-[var(--border)] px-2.5 py-0.5 text-[11px] text-[var(--text-muted)]">
           {channel.effort} effort
         </span>
-        <span className="rounded-full bg-white/[0.04] border border-white/[0.06] px-2.5 py-0.5 text-[11px] text-zinc-500">
+        <span className="rounded-full bg-[var(--surface-4)] border border-[var(--border)] px-2.5 py-0.5 text-[11px] text-[var(--text-muted)]">
           {channel.cost === 'free' ? 'Free' : `${channel.cost} cost`}
         </span>
       </div>
 
       {/* Why recommended */}
-      <div className="mb-4 rounded-lg bg-white/[0.03] border border-white/[0.04] p-3">
-        <h4 className="mb-1 text-[11px] font-medium text-zinc-600 uppercase tracking-wider">Why recommended</h4>
-        <p className="text-sm text-zinc-400">{reason}</p>
+      <div className="mb-4 rounded-lg bg-[var(--surface-3)] border border-[var(--border-subtle)] p-3">
+        <h4 className="mb-1 text-[11px] font-medium text-[var(--text-muted)] uppercase tracking-wider">Why recommended</h4>
+        <p className="text-sm text-[var(--text-tertiary)]">{reason}</p>
       </div>
 
       {/* Action items */}
       <div>
-        <h4 className="mb-2 text-[11px] font-medium text-zinc-600 uppercase tracking-wider">Action items</h4>
+        <h4 className="mb-2 text-[11px] font-medium text-[var(--text-muted)] uppercase tracking-wider">Action items</h4>
         <ul className="space-y-1.5">
           {actionItems.map((item, index) => (
             <li key={index} className="flex items-start gap-2">
@@ -93,8 +93,8 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
                 aria-label={`Mark "${item}" as ${checkedItems[index] ? 'incomplete' : 'complete'}`}
                 className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
                   checkedItems[index]
-                    ? 'border-zinc-500 bg-white text-black'
-                    : 'border-white/[0.12] bg-transparent hover:border-white/[0.25]'
+                    ? 'border-[var(--text-secondary)] bg-[var(--accent-bg)] text-[var(--accent-text)]'
+                    : 'border-[var(--border-hover)] bg-transparent hover:border-[var(--border-focus)]'
                 }`}
               >
                 {checkedItems[index] && (
@@ -105,7 +105,7 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
               </button>
               <span
                 className={`text-sm transition-colors ${
-                  checkedItems[index] ? 'text-zinc-700 line-through' : 'text-zinc-500'
+                  checkedItems[index] ? 'text-[var(--text-faint)] line-through' : 'text-[var(--text-secondary)]'
                 }`}
               >
                 {item}

--- a/src/components/ChannelList.tsx
+++ b/src/components/ChannelList.tsx
@@ -52,7 +52,7 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
       {/* Controls */}
       <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         {/* Filter tabs */}
-        <div role="tablist" aria-label="Filter channels by type" className="flex flex-wrap gap-1 rounded-lg border border-white/[0.06] bg-white/[0.02] p-1">
+        <div role="tablist" aria-label="Filter channels by type" className="flex flex-wrap gap-1 rounded-lg border border-[var(--border)] bg-[var(--surface-2)] p-1">
           {tabs.map((tab) => (
             <button
               key={tab.value}
@@ -62,8 +62,8 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
               onClick={() => handleTypeChange(tab.value)}
               className={`rounded-md px-3 py-1.5 text-sm font-medium transition-all ${
                 activeType === tab.value
-                  ? 'bg-white/[0.08] text-white'
-                  : 'text-zinc-600 hover:text-zinc-400'
+                  ? 'bg-[var(--surface-8)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-tertiary)]'
               }`}
             >
               {tab.label}
@@ -73,13 +73,13 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
 
         {/* Sort select */}
         <div className="flex items-center gap-2">
-          <label htmlFor="channel-sort" className="text-xs text-zinc-600 uppercase tracking-wider">Sort by</label>
+          <label htmlFor="channel-sort" className="text-xs text-[var(--text-muted)] uppercase tracking-wider">Sort by</label>
           <select
             id="channel-sort"
             value={sortBy}
             onChange={handleSortChange}
             aria-label="Sort channels"
-            className="rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-sm text-zinc-400 outline-none transition-colors focus:border-white/[0.15]"
+            className="rounded-lg border border-[var(--border-medium)] bg-[var(--surface-4)] px-3 py-1.5 text-sm text-[var(--text-tertiary)] outline-none transition-colors focus:border-[var(--border-hover)]"
           >
             <option value="relevance">Relevance</option>
             <option value="effort">Effort (low first)</option>
@@ -88,7 +88,7 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
       </div>
 
       {/* Results count */}
-      <p className="mb-4 text-xs text-zinc-600 font-[family-name:var(--font-code)]">
+      <p className="mb-4 text-xs text-[var(--text-muted)] font-[family-name:var(--font-code)]">
         {filtered.length} channel{filtered.length !== 1 ? 's' : ''} found
       </p>
 
@@ -102,7 +102,7 @@ export default function ChannelList({ recommendations }: { recommendations: Chan
       </div>
 
       {filtered.length === 0 && (
-        <div className="py-16 text-center text-zinc-700">
+        <div className="py-16 text-center text-[var(--text-faint)]">
           No channels match this filter.
         </div>
       )}

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -49,11 +49,11 @@ function ExportPanel({ data, planId }: ExportPanelProps) {
   }, [planId]);
 
   const btnClass =
-    'inline-flex items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-2 text-sm font-medium text-zinc-300 transition-all hover:bg-white/[0.08] hover:border-white/[0.12] active:scale-[0.97]';
+    'inline-flex items-center gap-2 rounded-lg border border-[var(--border-medium)] bg-[var(--surface-4)] px-4 py-2 text-sm font-medium text-[var(--text-secondary)] transition-all hover:bg-[var(--surface-8)] hover:border-[var(--border-hover)] active:scale-[0.97]';
 
   return (
-    <div className="relative rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 backdrop-blur-xl">
-      <h3 className="mb-4 text-sm font-bold text-zinc-100 uppercase tracking-wider">
+    <div className="relative rounded-xl border border-[var(--border-medium)] bg-[var(--surface-3)] p-6 backdrop-blur-xl">
+      <h3 className="mb-4 text-sm font-bold text-[var(--text-primary)] uppercase tracking-wider">
         Export &amp; Share
       </h3>
 
@@ -97,11 +97,11 @@ function ExportPanel({ data, planId }: ExportPanelProps) {
       </div>
 
       {/* Divider */}
-      <div className="my-4 border-t border-white/[0.06]" />
+      <div className="my-4 border-t border-[var(--border)]" />
 
       {/* Share section */}
       <div>
-        <p className="mb-2 text-xs text-zinc-600 uppercase tracking-wider">Share your launch plan</p>
+        <p className="mb-2 text-xs text-[var(--text-muted)] uppercase tracking-wider">Share your launch plan</p>
         <button
           onClick={handleCopyLink}
           aria-label="Copy shareable link to clipboard"
@@ -179,7 +179,7 @@ function CheckIcon() {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="text-zinc-300"
+      className="text-[var(--text-secondary)]"
     >
       <polyline points="20 6 9 17 4 12" />
     </svg>

--- a/src/components/OutreachEditor.tsx
+++ b/src/components/OutreachEditor.tsx
@@ -66,14 +66,14 @@ export default function OutreachEditor({
         {/* Channel Badge */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-white/[0.06] border border-white/[0.08] text-sm font-bold font-[family-name:var(--font-code)] text-zinc-400">
+            <span className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--surface-6)] border border-[var(--border-medium)] text-sm font-bold font-[family-name:var(--font-code)] text-[var(--text-tertiary)]">
               {channelIcons[template.channelType]}
             </span>
-            <h3 className="text-zinc-100 font-medium text-lg">
+            <h3 className="text-[var(--text-primary)] font-medium text-lg">
               {template.channelName}
             </h3>
             {isDone && (
-              <span className="text-[11px] bg-white/[0.06] text-zinc-400 px-2 py-0.5 rounded-full border border-white/[0.08]">
+              <span className="text-[11px] bg-[var(--surface-6)] text-[var(--text-tertiary)] px-2 py-0.5 rounded-full border border-[var(--border-medium)]">
                 Done
               </span>
             )}
@@ -81,7 +81,7 @@ export default function OutreachEditor({
           <button
             onClick={() => setShowTips(!showTips)}
             aria-label={showTips ? 'Hide tips' : 'Show tips'}
-            className="text-sm text-zinc-600 hover:text-zinc-400 transition-colors lg:hidden"
+            className="text-sm text-[var(--text-muted)] hover:text-[var(--text-tertiary)] transition-colors lg:hidden"
           >
             {showTips ? 'Hide tips' : 'Show tips'}
           </button>
@@ -90,14 +90,14 @@ export default function OutreachEditor({
         {/* Subject Field */}
         {template.subject !== undefined && (
           <div>
-            <label className="block text-[11px] text-zinc-600 mb-1 uppercase tracking-wider">
+            <label className="block text-[11px] text-[var(--text-muted)] mb-1 uppercase tracking-wider">
               Subject / Title
             </label>
             <input
               type="text"
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
-              className="w-full bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2 text-zinc-100 font-[family-name:var(--font-code)] text-sm focus:outline-none focus:border-white/[0.2] focus:ring-1 focus:ring-white/[0.1] placeholder-zinc-700"
+              className="w-full bg-[var(--surface-4)] border border-[var(--border-medium)] rounded-lg px-3 py-2 text-[var(--text-primary)] font-[family-name:var(--font-code)] text-sm focus:outline-none focus:border-[var(--border-focus)] focus:ring-1 focus:ring-[var(--ring-focus)] placeholder-[var(--placeholder)]"
               placeholder="Subject line..."
             />
           </div>
@@ -105,14 +105,14 @@ export default function OutreachEditor({
 
         {/* Body Editor */}
         <div className="flex-1 flex flex-col">
-          <label className="block text-[11px] text-zinc-600 mb-1 uppercase tracking-wider">
+          <label className="block text-[11px] text-[var(--text-muted)] mb-1 uppercase tracking-wider">
             Body
           </label>
           <textarea
             value={body}
             onChange={(e) => setBody(e.target.value)}
             aria-describedby="outreach-char-count"
-            className="flex-1 min-h-[280px] w-full bg-white/[0.04] border border-white/[0.08] rounded-lg px-4 py-3 text-zinc-100 font-[family-name:var(--font-code)] text-sm leading-relaxed focus:outline-none focus:border-white/[0.2] focus:ring-1 focus:ring-white/[0.1] placeholder-zinc-700 resize-none"
+            className="flex-1 min-h-[280px] w-full bg-[var(--surface-4)] border border-[var(--border-medium)] rounded-lg px-4 py-3 text-[var(--text-primary)] font-[family-name:var(--font-code)] text-sm leading-relaxed focus:outline-none focus:border-[var(--border-focus)] focus:ring-1 focus:ring-[var(--ring-focus)] placeholder-[var(--placeholder)] resize-none"
             placeholder="Write your outreach message..."
           />
         </div>
@@ -126,8 +126,8 @@ export default function OutreachEditor({
                 isOverLimit
                   ? 'text-red-400'
                   : template.characterLimit
-                    ? 'text-zinc-600'
-                    : 'text-zinc-700'
+                    ? 'text-[var(--text-muted)]'
+                    : 'text-[var(--text-faint)]'
               }`}
             >
               {characterCount}
@@ -145,7 +145,7 @@ export default function OutreachEditor({
           <div className="flex items-center gap-2">
             <button
               onClick={resetToTemplate}
-              className="px-3 py-1.5 text-xs text-zinc-600 hover:text-zinc-400 border border-white/[0.06] hover:border-white/[0.12] rounded-lg transition-all"
+              className="px-3 py-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text-tertiary)] border border-[var(--border)] hover:border-[var(--border-hover)] rounded-lg transition-all"
             >
               Reset to template
             </button>
@@ -153,8 +153,8 @@ export default function OutreachEditor({
               onClick={copyToClipboard}
               className={`px-4 py-1.5 text-sm font-medium rounded-lg transition-all ${
                 copied
-                  ? 'bg-white/[0.08] text-zinc-300 border border-white/[0.12]'
-                  : 'bg-white text-black hover:bg-zinc-200 active:scale-[0.97]'
+                  ? 'bg-[var(--surface-8)] text-[var(--text-secondary)] border border-[var(--border-hover)]'
+                  : 'bg-[var(--accent-bg)] text-[var(--accent-text)] hover:bg-[var(--accent-hover)] active:scale-[0.97]'
               }`}
             >
               {copied ? 'Copied!' : 'Copy to clipboard'}
@@ -166,8 +166,8 @@ export default function OutreachEditor({
       {/* Tips Sidebar */}
       {showTips && (
         <div className="lg:w-72 shrink-0">
-          <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-4">
-            <h4 className="text-[11px] font-medium text-zinc-500 mb-3 uppercase tracking-wider">
+          <div className="bg-[var(--surface-3)] border border-[var(--border)] rounded-xl p-4">
+            <h4 className="text-[11px] font-medium text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
               Tips for {template.channelName}
             </h4>
             <ul className="space-y-2">
@@ -179,10 +179,10 @@ export default function OutreachEditor({
                     key={i}
                     className={`text-xs leading-relaxed ${
                       isDo
-                        ? 'text-zinc-400'
+                        ? 'text-[var(--text-tertiary)]'
                         : isDont
-                          ? 'text-zinc-600'
-                          : 'text-zinc-500'
+                          ? 'text-[var(--text-muted)]'
+                          : 'text-[var(--text-secondary)]'
                     }`}
                   >
                     {tip}

--- a/src/components/OutreachWorkspace.tsx
+++ b/src/components/OutreachWorkspace.tsx
@@ -42,30 +42,30 @@ export default function OutreachWorkspace({
   const progressPercent = Math.round((progress / total) * 100);
 
   return (
-    <div className="min-h-screen bg-black text-white p-4 md:p-8">
+    <div className="min-h-screen bg-[var(--bg-page)] text-[var(--text-primary)] p-4 md:p-8">
       <div className="max-w-6xl mx-auto space-y-6">
         {/* Header */}
         <div className="space-y-2">
-          <h2 className="text-2xl font-bold tracking-tight text-white">
+          <h2 className="text-2xl font-bold tracking-tight text-[var(--text-primary)]">
             Outreach Workspace
           </h2>
-          <p className="text-sm text-zinc-600">
+          <p className="text-sm text-[var(--text-muted)]">
             Customize and copy launch templates for each channel. Edit the
             placeholders, then copy when ready.
           </p>
         </div>
 
         {/* Progress Bar */}
-        <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-4">
+        <div className="bg-[var(--surface-3)] border border-[var(--border)] rounded-xl p-4">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm text-zinc-500">Launch progress</span>
-            <span className="text-sm font-[family-name:var(--font-code)] text-zinc-600">
+            <span className="text-sm text-[var(--text-secondary)]">Launch progress</span>
+            <span className="text-sm font-[family-name:var(--font-code)] text-[var(--text-muted)]">
               {progress}/{total} channels ready
             </span>
           </div>
-          <div className="h-1.5 bg-white/[0.04] rounded-full overflow-hidden">
+          <div className="h-1.5 bg-[var(--surface-4)] rounded-full overflow-hidden">
             <div
-              className="h-full bg-white/30 rounded-full transition-all duration-500 ease-out"
+              className="h-full bg-[var(--progress-fill)] rounded-full transition-all duration-500 ease-out"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
@@ -83,14 +83,14 @@ export default function OutreachWorkspace({
                 onClick={() => setActiveTemplateId(template.id)}
                 className={`px-3 py-2 text-sm rounded-lg border transition-all ${
                   isActive
-                    ? 'bg-white/[0.08] border-white/[0.12] text-white'
-                    : 'border-white/[0.04] text-zinc-600 hover:text-zinc-400 hover:border-white/[0.08]'
+                    ? 'bg-[var(--surface-8)] border-[var(--border-hover)] text-[var(--text-primary)]'
+                    : 'border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-tertiary)] hover:border-[var(--border-medium)]'
                 }`}
               >
                 <span className="flex items-center gap-1.5">
                   {template.channelName}
                   {isDone && (
-                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-zinc-400" />
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)]" />
                   )}
                 </span>
               </button>
@@ -99,7 +99,7 @@ export default function OutreachWorkspace({
         </div>
 
         {/* Editor */}
-        <div className="bg-white/[0.03] border border-white/[0.06] rounded-2xl p-5 md:p-6">
+        <div className="bg-[var(--surface-3)] border border-[var(--border)] rounded-2xl p-5 md:p-6">
           <OutreachEditor
             key={activeTemplate.id}
             template={activeTemplate}

--- a/src/components/ProjectForm.tsx
+++ b/src/components/ProjectForm.tsx
@@ -62,15 +62,15 @@ export default function ProjectForm({ onSubmit, isSubmitting = false }: ProjectF
   }
 
   const inputClass =
-    'w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3 text-zinc-100 placeholder-zinc-600 outline-none transition-all duration-200 focus:border-white/[0.2] focus:ring-1 focus:ring-white/[0.1] focus:bg-white/[0.06] text-sm';
+    'w-full rounded-xl border border-[var(--border-medium)] bg-[var(--surface-4)] px-4 py-3 text-[var(--text-primary)] placeholder-[var(--placeholder)] outline-none transition-all duration-200 focus:border-[var(--border-focus)] focus:ring-1 focus:ring-[var(--ring-focus)] focus:bg-[var(--surface-6)] text-sm';
 
-  const labelClass = 'block text-xs font-medium text-zinc-500 mb-1.5 uppercase tracking-wider';
+  const labelClass = 'block text-xs font-medium text-[var(--text-muted)] mb-1.5 uppercase tracking-wider';
 
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-xl mx-auto">
-      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-8 backdrop-blur-xl">
-        <h2 className="text-2xl font-bold text-white mb-1 tracking-tight">Launch your project</h2>
-        <p className="text-zinc-600 mb-8 text-sm">
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-2)] p-8 backdrop-blur-xl">
+        <h2 className="text-2xl font-bold text-[var(--text-primary)] mb-1 tracking-tight">Launch your project</h2>
+        <p className="text-[var(--text-muted)] mb-8 text-sm">
           Fill in the details and get a personalized launch plan.
         </p>
 
@@ -108,7 +108,7 @@ export default function ProjectForm({ onSubmit, isSubmitting = false }: ProjectF
               onChange={(e) => updateField('description', e.target.value)}
               disabled={isSubmitting}
             />
-            <p id="description-count" className="mt-1 text-xs text-white/40">
+            <p id="description-count" className="mt-1 text-xs text-[var(--text-muted)]">
               {formData.description.length}/200
             </p>
             {errors.description && (
@@ -152,13 +152,13 @@ export default function ProjectForm({ onSubmit, isSubmitting = false }: ProjectF
         </div>
 
         {/* Advanced Options */}
-        <div className="mt-8 border-t border-white/[0.06] pt-6">
+        <div className="mt-8 border-t border-[var(--border)] pt-6">
           <button
             type="button"
             onClick={() => setShowAdvanced((v) => !v)}
             aria-expanded={showAdvanced}
             aria-controls="advanced-options"
-            className="flex items-center gap-2 text-sm text-zinc-600 hover:text-zinc-400 transition-colors duration-200"
+            className="flex items-center gap-2 text-sm text-[var(--text-muted)] hover:text-[var(--text-tertiary)] transition-colors duration-200"
             disabled={isSubmitting}
           >
             <svg
@@ -283,10 +283,10 @@ export default function ProjectForm({ onSubmit, isSubmitting = false }: ProjectF
         <button
           type="submit"
           disabled={isSubmitting}
-          className="mt-8 w-full rounded-xl bg-white px-6 py-3.5 text-sm font-semibold text-black transition-all duration-150 hover:bg-zinc-200 active:scale-[0.97] disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:shadow-none disabled:active:scale-100 flex items-center justify-center gap-2"
+          className="mt-8 w-full rounded-xl bg-[var(--accent-bg)] px-6 py-3.5 text-sm font-semibold text-[var(--accent-text)] transition-all duration-150 hover:bg-[var(--accent-hover)] active:scale-[0.97] disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:shadow-none disabled:active:scale-100 flex items-center justify-center gap-2"
         >
           {isSubmitting && (
-            <span className="h-4 w-4 rounded-full border-2 border-gray-900/30 border-t-gray-900 animate-spin" />
+            <span className="h-4 w-4 rounded-full border-2 border-[var(--accent-text)]/30 border-t-[var(--accent-text)] animate-spin" />
           )}
           {isSubmitting ? 'Generating...' : 'Generate Launch Plan'}
         </button>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'dark' | 'light';
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  toggleTheme: () => void;
+}>({ theme: 'dark', toggleTheme: () => {} });
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+      document.documentElement.setAttribute('data-theme', stored);
+    }
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    document.documentElement.setAttribute('data-theme', next);
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useTheme } from './ThemeProvider';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      className="fixed top-6 right-6 z-50 flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-medium)] bg-[var(--surface-4)] backdrop-blur-sm transition-all hover:bg-[var(--surface-8)] hover:border-[var(--border-hover)]"
+    >
+      {theme === 'dark' ? (
+        <svg
+          className="h-4 w-4 text-[var(--text-tertiary)]"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="h-4 w-4 text-[var(--text-tertiary)]"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a theme toggle button (fixed top-right corner) for switching between dark and light themes
- Use CSS custom properties for all theme-aware colors, keeping glassmorphism aesthetic in both themes
- Persist theme preference in localStorage with dark as default
- Inline script in `<head>` prevents flash of incorrect theme on page load

## Changes
- **New**: `ThemeProvider.tsx` — React context managing theme state + localStorage
- **New**: `ThemeToggle.tsx` — Sun/moon toggle button (fixed position, top-right)
- **Updated**: `globals.css` — CSS custom properties for both dark and light theme tokens
- **Updated**: `layout.tsx` — Wraps app in ThemeProvider, includes ThemeToggle and anti-FOUC script
- **Updated**: All page and component files — replaced hardcoded dark-mode colors with CSS variable references

## Test plan
- [x] All 37 existing tests pass
- [ ] Toggle between dark and light themes — both should maintain glassmorphism aesthetic
- [ ] Refresh page — theme preference should persist via localStorage
- [ ] First visit defaults to dark theme

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dark and light theme support with theme toggle button for easy switching between modes
  * Theme preference is automatically saved and restored across sessions

* **Style**
  * Migrated app styling to a comprehensive CSS variable-based design system for improved visual consistency and theming capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->