### PR TITLE
fix: remove redundant * 100 on relevanceScore display

### DIFF
--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -11,7 +11,7 @@ function ChannelCard({ recommendation }: { recommendation: ChannelRecommendation
     setCheckedItems((prev) => ({ ...prev, [index]: !prev[index] }));
   };
 
-  const scorePercent = Math.round(relevanceScore * 100);
+  const scorePercent = Math.round(relevanceScore);
 
   return (
     <div role="article" className="group relative rounded-xl border border-[var(--border)] bg-[var(--surface-2)] p-6 transition-all duration-300 hover:border-[var(--border-hover)] hover:bg-[var(--surface-4)]">


### PR DESCRIPTION
## Summary
- **Fixes #61** — `scoreChannel()` in `engine.ts` returns 0–100, but `ChannelCard.tsx` was multiplying by 100 again, producing 5000–7000% values
- Removed the `* 100` multiplier so `scorePercent` correctly reflects the 0–100 engine output

## Test plan
- [x] All 41 existing tests pass
- [x] Lint passes with no errors
- [ ] Verify relevance scores display as expected percentages (0–100%) in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relevance score display to properly reflect values on the 0-100 scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->