### PR TITLE
docs: add live demo link and Deploy to Vercel button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
 </p>
 
 <p align="center">
+  <a href="https://automatic-launcher.vercel.app"><img src="https://img.shields.io/badge/live%20demo-automatic--launcher.vercel.app-black?style=for-the-badge&logo=vercel" alt="Live Demo" /></a>
+  &nbsp;
+  <a href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FNikitaDmitrieff%2Fautomatic-launcher"><img src="https://vercel.com/button" alt="Deploy with Vercel" /></a>
+</p>
+
+<p align="center">
+  <a href="https://automatic-launcher.vercel.app">Live Demo</a> &middot;
   <a href="#quickstart">Quickstart</a> &middot;
   <a href="#features">Features</a> &middot;
   <a href="#how-it-works">How It Works</a> &middot;


### PR DESCRIPTION
## Summary
- Add a **Live Demo** badge linking to `automatic-launcher.vercel.app`
- Add a one-click **Deploy with Vercel** button for easy self-hosting
- Add "Live Demo" link to the navigation bar

Closes #65

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify "Deploy with Vercel" button links to the correct clone URL
- [ ] Verify live demo badge links to the deployed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added live demo and deployment badges to the README
  * Extended navigation with Roadmap and Contributing links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->