### PR TITLE
fix: clean up setTimeout memory leaks in OutreachEditor and ExportPanel

### DIFF
--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
   type ExportData,
   exportToMarkdown,
@@ -20,11 +20,24 @@ function ExportPanel({ data, planId }: ExportPanelProps) {
   const [markdownCopyState, setMarkdownCopyState] = useState<CopyState>('idle');
   const [linkCopyState, setLinkCopyState] = useState<CopyState>('idle');
 
+  useEffect(() => {
+    if (markdownCopyState === 'copied') {
+      const timer = setTimeout(() => setMarkdownCopyState('idle'), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [markdownCopyState]);
+
+  useEffect(() => {
+    if (linkCopyState === 'copied') {
+      const timer = setTimeout(() => setLinkCopyState('idle'), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [linkCopyState]);
+
   const handleCopyMarkdown = useCallback(async () => {
     const md = exportToMarkdown(data);
     await copyToClipboard(md);
     setMarkdownCopyState('copied');
-    setTimeout(() => setMarkdownCopyState('idle'), 2000);
   }, [data]);
 
   const handleDownloadMarkdown = useCallback(() => {
@@ -45,7 +58,6 @@ function ExportPanel({ data, planId }: ExportPanelProps) {
       : window.location.href;
     await copyToClipboard(shareUrl);
     setLinkCopyState('copied');
-    setTimeout(() => setLinkCopyState('idle'), 2000);
   }, [planId]);
 
   const btnClass =

--- a/src/components/OutreachEditor.tsx
+++ b/src/components/OutreachEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { OutreachTemplate } from '../types/outreach';
 
 const channelIcons: Record<OutreachTemplate['channelType'], string> = {
@@ -36,6 +36,13 @@ export default function OutreachEditor({
     template.characterLimit !== undefined &&
     characterCount > template.characterLimit;
 
+  useEffect(() => {
+    if (copied) {
+      const timer = setTimeout(() => setCopied(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
+
   const resetToTemplate = useCallback(() => {
     setSubject(template.subject ?? '');
     setBody(template.body);
@@ -47,7 +54,6 @@ export default function OutreachEditor({
       await navigator.clipboard.writeText(fullText);
       setCopied(true);
       onMarkDone(template.id);
-      setTimeout(() => setCopied(false), 2000);
     } catch {
       const textarea = document.createElement('textarea');
       textarea.value = fullText;
@@ -57,7 +63,6 @@ export default function OutreachEditor({
       document.body.removeChild(textarea);
       setCopied(true);
       onMarkDone(template.id);
-      setTimeout(() => setCopied(false), 2000);
     }
   }, [subject, body, template.id, onMarkDone]);
 


### PR DESCRIPTION
## Summary
- Replaced `setTimeout` calls in event handlers with `useEffect` + cleanup pattern in `OutreachEditor.tsx` and `ExportPanel.tsx`
- Prevents state updates on unmounted components by clearing timers on cleanup

Closes #77

## Test plan
- [x] All 75 existing tests pass
- [x] No lint errors
- [ ] Manual: copy-to-clipboard in OutreachEditor resets "Copied!" after 2s
- [ ] Manual: copy markdown/link in ExportPanel resets feedback after 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced state management for copy-to-clipboard notifications in export and outreach features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->