### PR TITLE
fix: align URL validation to require HTTPS and verify JSON error handling

### DIFF
--- a/__tests__/validation.test.ts
+++ b/__tests__/validation.test.ts
@@ -133,6 +133,22 @@ describe('createPlanSchema', () => {
       });
       expect(result.success).toBe(true);
     });
+
+    it('rejects http:// repoUrl (requires https://)', () => {
+      const result = createPlanSchema.safeParse({
+        ...validInput,
+        repoUrl: 'http://github.com/user/repo',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http:// demoUrl (requires https://)', () => {
+      const result = createPlanSchema.safeParse({
+        ...validInput,
+        demoUrl: 'http://example.com',
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('enum validation', () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -14,11 +14,17 @@ export const createPlanSchema = z.object({
   repoUrl: z
     .string()
     .url('Invalid URL format for repository URL')
+    .refine((url) => url.startsWith('https://'), {
+      message: 'URL must start with https://',
+    })
     .optional()
     .or(z.literal('')),
   demoUrl: z
     .string()
     .url('Invalid URL format for demo URL')
+    .refine((url) => url.startsWith('https://'), {
+      message: 'URL must start with https://',
+    })
     .optional()
     .or(z.literal('')),
   tags: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- Aligned backend Zod URL validation with frontend HTTPS requirement by adding `.refine()` checks on `repoUrl` and `demoUrl` in `src/lib/validation.ts`
- Added tests verifying `http://` URLs are rejected for both fields
- Verified JSON parse error handling was already in place for both `src/app/api/plans/route.ts` and `src/app/api/plans/[id]/route.ts`

Closes #80

## Test plan
- [x] All 77 existing tests pass
- [x] New tests verify `http://` URLs are rejected for repoUrl and demoUrl
- [x] Lint passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL validation now requires HTTPS protocol for repository and demo URLs, enhancing security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->