### PR TITLE
test: add missing component tests for 5 components

### DIFF
--- a/__tests__/components/ChannelList.test.tsx
+++ b/__tests__/components/ChannelList.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChannelList from '../../src/components/ChannelList';
+import type { ChannelRecommendation } from '../../src/types/recommendation';
+
+function makeRec(overrides: Partial<ChannelRecommendation> & { name: string; type: ChannelRecommendation['channel']['type']; effort: ChannelRecommendation['channel']['effort']; score: number }): ChannelRecommendation {
+  return {
+    channel: {
+      name: overrides.name,
+      type: overrides.type,
+      url: `https://example.com/${overrides.name.toLowerCase().replace(/\s/g, '-')}`,
+      description: `${overrides.name} description`,
+      audienceSize: '10k+',
+      effort: overrides.effort,
+      cost: 'free',
+    },
+    relevanceScore: overrides.score,
+    reason: `Reason for ${overrides.name}`,
+    actionItems: ['Action 1'],
+  };
+}
+
+const recommendations: ChannelRecommendation[] = [
+  makeRec({ name: 'Reddit', type: 'social', effort: 'low', score: 90 }),
+  makeRec({ name: 'HN', type: 'news', effort: 'medium', score: 80 }),
+  makeRec({ name: 'Discord', type: 'community', effort: 'high', score: 70 }),
+  makeRec({ name: 'PH Directory', type: 'directory', effort: 'low', score: 60 }),
+  makeRec({ name: 'Newsletter', type: 'email', effort: 'medium', score: 50 }),
+];
+
+describe('ChannelList', () => {
+  it('renders all channels by default', () => {
+    render(<ChannelList recommendations={recommendations} />);
+    expect(screen.getByText('5 channels found')).toBeDefined();
+  });
+
+  it('renders filter tabs', () => {
+    render(<ChannelList recommendations={recommendations} />);
+    expect(screen.getByRole('tab', { name: /filter by all/i })).toBeDefined();
+    expect(screen.getByRole('tab', { name: /filter by social/i })).toBeDefined();
+    expect(screen.getByRole('tab', { name: /filter by community/i })).toBeDefined();
+    expect(screen.getByRole('tab', { name: /filter by news/i })).toBeDefined();
+  });
+
+  it('filters channels by type when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ChannelList recommendations={recommendations} />);
+
+    await user.click(screen.getByRole('tab', { name: /filter by social/i }));
+
+    expect(screen.getByText('1 channel found')).toBeDefined();
+    expect(screen.getByText('Reddit')).toBeDefined();
+  });
+
+  it('shows "All" tab as selected by default', () => {
+    render(<ChannelList recommendations={recommendations} />);
+    const allTab = screen.getByRole('tab', { name: /filter by all/i });
+    expect(allTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('updates aria-selected when switching tabs', async () => {
+    const user = userEvent.setup();
+    render(<ChannelList recommendations={recommendations} />);
+
+    const newsTab = screen.getByRole('tab', { name: /filter by news/i });
+    await user.click(newsTab);
+
+    expect(newsTab.getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /filter by all/i }).getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('sorts by relevance by default (descending)', () => {
+    render(<ChannelList recommendations={recommendations} />);
+    const articles = screen.getAllByRole('article');
+    expect(articles[0].textContent).toContain('Reddit');
+    expect(articles[4].textContent).toContain('Newsletter');
+  });
+
+  it('sorts by effort when selected', async () => {
+    const user = userEvent.setup();
+    render(<ChannelList recommendations={recommendations} />);
+
+    await user.selectOptions(screen.getByLabelText(/sort channels/i), 'effort');
+
+    const articles = screen.getAllByRole('article');
+    // Low effort first: Reddit (low), PH Directory (low), then medium, then high
+    expect(articles[0].textContent).toContain('Reddit');
+    expect(articles[1].textContent).toContain('PH Directory');
+    expect(articles[4].textContent).toContain('Discord');
+  });
+
+  it('shows empty state when no channels match filter', async () => {
+    const onlySocial = [makeRec({ name: 'Twitter', type: 'social', effort: 'low', score: 80 })];
+    const user = userEvent.setup();
+    render(<ChannelList recommendations={onlySocial} />);
+
+    await user.click(screen.getByRole('tab', { name: /filter by news/i }));
+
+    expect(screen.getByText('No channels match this filter.')).toBeDefined();
+    expect(screen.getByText('0 channels found')).toBeDefined();
+  });
+
+  it('handles empty recommendations list', () => {
+    render(<ChannelList recommendations={[]} />);
+    expect(screen.getByText('0 channels found')).toBeDefined();
+    expect(screen.getByText('No channels match this filter.')).toBeDefined();
+  });
+
+  it('combines filter and sort', async () => {
+    const recs = [
+      makeRec({ name: 'Reddit', type: 'social', effort: 'high', score: 90 }),
+      makeRec({ name: 'Twitter', type: 'social', effort: 'low', score: 70 }),
+    ];
+    const user = userEvent.setup();
+    render(<ChannelList recommendations={recs} />);
+
+    await user.click(screen.getByRole('tab', { name: /filter by social/i }));
+    await user.selectOptions(screen.getByLabelText(/sort channels/i), 'effort');
+
+    const articles = screen.getAllByRole('article');
+    expect(articles[0].textContent).toContain('Twitter'); // low effort first
+    expect(articles[1].textContent).toContain('Reddit'); // high effort second
+  });
+});

--- a/__tests__/components/ExportPanel.test.tsx
+++ b/__tests__/components/ExportPanel.test.tsx
@@ -65,8 +65,8 @@ describe('ExportPanel', () => {
     await user.click(screen.getByLabelText('Copy launch plan as Markdown'));
     expect(screen.getByText('Copied!')).toBeDefined();
 
-    act(() => {
-      vi.advanceTimersByTime(2000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
     });
 
     expect(screen.getByText('Copy as Markdown')).toBeDefined();

--- a/__tests__/components/ExportPanel.test.tsx
+++ b/__tests__/components/ExportPanel.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ExportData } from '../../src/lib/exporters';
+
+const { copyToClipboardMock, downloadFileMock } = vi.hoisted(() => ({
+  copyToClipboardMock: vi.fn().mockResolvedValue(undefined),
+  downloadFileMock: vi.fn(),
+}));
+
+vi.mock('@/lib/exporters', async () => {
+  const actual = await vi.importActual<typeof import('../../src/lib/exporters')>('../../src/lib/exporters');
+  return {
+    ...actual,
+    copyToClipboard: copyToClipboardMock,
+    downloadFile: downloadFileMock,
+  };
+});
+
+import ExportPanel from '../../src/components/ExportPanel';
+
+const testData: ExportData = {
+  projectName: 'Test App',
+  channels: [
+    { name: 'Reddit', url: 'https://reddit.com', reason: 'Popular', actionItems: ['Post'] },
+  ],
+  timeline: [
+    { day: 1, title: 'Launch', tasks: ['Post on Reddit'] },
+  ],
+  templates: [
+    { channelName: 'Reddit', subject: 'Show Reddit', body: 'Check it out' },
+  ],
+};
+
+describe('ExportPanel', () => {
+  beforeEach(() => {
+    copyToClipboardMock.mockClear();
+    downloadFileMock.mockClear();
+  });
+
+  it('renders export heading and all buttons', () => {
+    render(<ExportPanel data={testData} />);
+    expect(screen.getByText('Export & Share')).toBeDefined();
+    expect(screen.getByLabelText('Copy launch plan as Markdown')).toBeDefined();
+    expect(screen.getByLabelText('Download launch plan as Markdown file')).toBeDefined();
+    expect(screen.getByLabelText('Download launch plan as JSON file')).toBeDefined();
+    expect(screen.getByLabelText('Copy shareable link to clipboard')).toBeDefined();
+  });
+
+  it('copies markdown to clipboard and shows feedback', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel data={testData} />);
+
+    await user.click(screen.getByLabelText('Copy launch plan as Markdown'));
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith(expect.stringContaining('# Test App'));
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
+
+  it('reverts copy state after timeout', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<ExportPanel data={testData} />);
+
+    await user.click(screen.getByLabelText('Copy launch plan as Markdown'));
+    expect(screen.getByText('Copied!')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText('Copy as Markdown')).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it('downloads markdown file', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel data={testData} />);
+
+    await user.click(screen.getByLabelText('Download launch plan as Markdown file'));
+
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-app-launch-plan.md',
+      'text/markdown'
+    );
+  });
+
+  it('downloads JSON file', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel data={testData} />);
+
+    await user.click(screen.getByLabelText('Download launch plan as JSON file'));
+
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-app-launch-plan.json',
+      'application/json'
+    );
+  });
+
+  it('copies share link with planId', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel data={testData} planId="abc123" />);
+
+    await user.click(screen.getByLabelText('Copy shareable link to clipboard'));
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith(expect.stringContaining('/results?id=abc123'));
+    expect(screen.getByText('Link copied!')).toBeDefined();
+  });
+
+  it('copies current URL when no planId', async () => {
+    const user = userEvent.setup();
+    render(<ExportPanel data={testData} />);
+
+    await user.click(screen.getByLabelText('Copy shareable link to clipboard'));
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith(window.location.href);
+  });
+
+  it('generates correct filename for project names with spaces', async () => {
+    const user = userEvent.setup();
+    const dataWithSpaces = { ...testData, projectName: 'My Cool App' };
+    render(<ExportPanel data={dataWithSpaces} />);
+
+    await user.click(screen.getByLabelText('Download launch plan as Markdown file'));
+
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'my-cool-app-launch-plan.md',
+      'text/markdown'
+    );
+  });
+});

--- a/__tests__/components/OutreachEditor.test.tsx
+++ b/__tests__/components/OutreachEditor.test.tsx
@@ -141,8 +141,8 @@ describe('OutreachEditor', () => {
     await user.click(screen.getByText('Copy to clipboard'));
     expect(screen.getByText('Copied!')).toBeDefined();
 
-    act(() => {
-      vi.advanceTimersByTime(2000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
     });
 
     expect(screen.getByText('Copy to clipboard')).toBeDefined();

--- a/__tests__/components/OutreachEditor.test.tsx
+++ b/__tests__/components/OutreachEditor.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OutreachEditor from '../../src/components/OutreachEditor';
+import type { OutreachTemplate } from '../../src/types/outreach';
+
+const baseTemplate: OutreachTemplate = {
+  id: 'test-template',
+  channelName: 'Test Channel',
+  channelType: 'reddit',
+  subject: 'Test Subject',
+  body: 'Hello world, this is the body.',
+  tips: ['DO: Be genuine', "DON'T: Spam", 'General tip'],
+  characterLimit: 280,
+};
+
+const templateWithoutSubject: OutreachTemplate = {
+  id: 'no-subject',
+  channelName: 'Community',
+  channelType: 'community',
+  body: 'Community post body',
+  tips: ['Tip 1'],
+};
+
+describe('OutreachEditor', () => {
+  let onMarkDone: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onMarkDone = vi.fn();
+  });
+
+  it('renders channel name and badge', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+    expect(screen.getByText('Test Channel')).toBeDefined();
+    expect(screen.getByText('R')).toBeDefined(); // reddit icon
+  });
+
+  it('renders subject field when template has subject', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+    const subjectInput = screen.getByPlaceholderText('Subject line...');
+    expect(subjectInput).toBeDefined();
+    expect((subjectInput as HTMLInputElement).value).toBe('Test Subject');
+  });
+
+  it('does not render subject field when template has no subject', () => {
+    render(<OutreachEditor template={templateWithoutSubject} onMarkDone={onMarkDone} isDone={false} />);
+    expect(screen.queryByPlaceholderText('Subject line...')).toBeNull();
+  });
+
+  it('renders body textarea with template body', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+    const textarea = screen.getByPlaceholderText('Write your outreach message...');
+    expect((textarea as HTMLTextAreaElement).value).toBe('Hello world, this is the body.');
+  });
+
+  it('shows character count', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+    expect(screen.getByText('30 / 280')).toBeDefined();
+  });
+
+  it('shows over-limit warning when body exceeds character limit', async () => {
+    const user = userEvent.setup();
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+
+    const textarea = screen.getByPlaceholderText('Write your outreach message...');
+    await user.clear(textarea);
+    await user.type(textarea, 'x'.repeat(285));
+
+    expect(screen.getByText(/over limit by 5/i)).toBeDefined();
+  });
+
+  it('shows "chars" when no character limit', () => {
+    render(<OutreachEditor template={templateWithoutSubject} onMarkDone={onMarkDone} isDone={false} />);
+    expect(screen.getByText('19 chars')).toBeDefined();
+  });
+
+  it('copies to clipboard and calls onMarkDone', async () => {
+    const user = userEvent.setup();
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+
+    await user.click(screen.getByText('Copy to clipboard'));
+
+    expect(onMarkDone).toHaveBeenCalledWith('test-template');
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
+
+  it('copies only body when no subject and marks done', async () => {
+    const user = userEvent.setup();
+    render(<OutreachEditor template={templateWithoutSubject} onMarkDone={onMarkDone} isDone={false} />);
+
+    await user.click(screen.getByText('Copy to clipboard'));
+
+    expect(onMarkDone).toHaveBeenCalledWith('no-subject');
+    expect(screen.getByText('Copied!')).toBeDefined();
+  });
+
+  it('resets to template values when reset button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+
+    const textarea = screen.getByPlaceholderText('Write your outreach message...');
+    await user.clear(textarea);
+    await user.type(textarea, 'Modified body');
+
+    await user.click(screen.getByText('Reset to template'));
+
+    expect((textarea as HTMLTextAreaElement).value).toBe('Hello world, this is the body.');
+  });
+
+  it('shows Done badge when isDone is true', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={true} />);
+    expect(screen.getByText('Done')).toBeDefined();
+  });
+
+  it('renders tips', () => {
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+    expect(screen.getByText('DO: Be genuine')).toBeDefined();
+    expect(screen.getByText("DON'T: Spam")).toBeDefined();
+    expect(screen.getByText('General tip')).toBeDefined();
+  });
+
+  it('toggles tips visibility on mobile button', async () => {
+    const user = userEvent.setup();
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+
+    // Tips visible by default
+    expect(screen.getByText('DO: Be genuine')).toBeDefined();
+
+    await user.click(screen.getByLabelText('Hide tips'));
+    expect(screen.queryByText('DO: Be genuine')).toBeNull();
+
+    await user.click(screen.getByLabelText('Show tips'));
+    expect(screen.getByText('DO: Be genuine')).toBeDefined();
+  });
+
+  it('reverts copied state after timeout', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<OutreachEditor template={baseTemplate} onMarkDone={onMarkDone} isDone={false} />);
+
+    await user.click(screen.getByText('Copy to clipboard'));
+    expect(screen.getByText('Copied!')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText('Copy to clipboard')).toBeDefined();
+    vi.useRealTimers();
+  });
+});

--- a/__tests__/components/OutreachWorkspace.test.tsx
+++ b/__tests__/components/OutreachWorkspace.test.tsx
@@ -1,21 +1,64 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import OutreachWorkspace from '../../src/components/OutreachWorkspace';
+import { outreachTemplates } from '../../src/lib/templates';
+
+// Mock clipboard
+beforeEach(() => {
+  const clipboardMock = { writeText: vi.fn().mockResolvedValue(undefined) };
+  Object.defineProperty(navigator, 'clipboard', { value: clipboardMock, writable: true, configurable: true });
+});
 
 describe('OutreachWorkspace', () => {
-  it('renders with default props', () => {
+  it('renders heading and description', () => {
     render(<OutreachWorkspace />);
-
     expect(screen.getByText('Outreach Workspace')).toBeDefined();
+    expect(screen.getByText(/customize and copy launch templates/i)).toBeDefined();
   });
 
-  it('renders channel tabs for all templates', () => {
+  it('renders a tab for each outreach template', () => {
     render(<OutreachWorkspace />);
+    for (const template of outreachTemplates) {
+      const escaped = template.channelName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      expect(screen.getByRole('button', { name: new RegExp(escaped) })).toBeDefined();
+    }
+  });
 
-    expect(screen.getAllByText('Reddit (r/SideProject)').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Hacker News (Show HN)').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Product Hunt').length).toBeGreaterThan(0);
+  it('shows progress bar starting at 0', () => {
+    render(<OutreachWorkspace />);
+    expect(screen.getByText(`0/${outreachTemplates.length} channels ready`)).toBeDefined();
+  });
+
+  it('fills templates with provided project data', () => {
+    render(
+      <OutreachWorkspace
+        projectName="LaunchBot"
+        description="AI launch copilot"
+        demoUrl="https://launchbot.dev"
+      />
+    );
+    // The first template (Reddit) should have placeholders filled
+    const textarea = screen.getByPlaceholderText('Write your outreach message...');
+    expect((textarea as HTMLTextAreaElement).value).toContain('LaunchBot');
+  });
+
+  it('uses placeholder values when no props provided', () => {
+    render(<OutreachWorkspace />);
+    const textarea = screen.getByPlaceholderText('Write your outreach message...');
+    expect((textarea as HTMLTextAreaElement).value).toContain('{{projectName}}');
+  });
+
+  it('switches active template when tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<OutreachWorkspace projectName="TestApp" description="test" demoUrl="https://test.com" />);
+
+    // Click on the second template tab
+    const secondTemplate = outreachTemplates[1];
+    await user.click(screen.getByRole('button', { name: new RegExp(secondTemplate.channelName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) }));
+
+    // The editor should now show the second template's channel name in the heading
+    expect(screen.getByRole('heading', { name: secondTemplate.channelName })).toBeDefined();
   });
 
   it('falls back to first template when activeTemplateId does not match', async () => {
@@ -40,5 +83,45 @@ describe('OutreachWorkspace', () => {
     );
 
     expect(screen.getByText('Outreach Workspace')).toBeDefined();
+  });
+
+  it('updates progress when a template is copied (marked done)', async () => {
+    const user = userEvent.setup();
+    render(<OutreachWorkspace projectName="TestApp" description="test" demoUrl="https://test.com" />);
+
+    // Copy the current template
+    await user.click(screen.getByText('Copy to clipboard'));
+
+    expect(screen.getByText(`1/${outreachTemplates.length} channels ready`)).toBeDefined();
+  });
+
+  it('does not double-count the same template marked done twice', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<OutreachWorkspace projectName="TestApp" description="test" demoUrl="https://test.com" />);
+
+    await user.click(screen.getByText('Copy to clipboard'));
+    // Wait for "Copied!" to revert back to "Copy to clipboard"
+    act(() => { vi.advanceTimersByTime(2000); });
+    await user.click(screen.getByText('Copy to clipboard'));
+
+    expect(screen.getByText(`1/${outreachTemplates.length} channels ready`)).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it('tracks progress across multiple templates', async () => {
+    const user = userEvent.setup();
+    render(<OutreachWorkspace projectName="TestApp" description="test" demoUrl="https://test.com" />);
+
+    // Copy first template
+    await user.click(screen.getByText('Copy to clipboard'));
+    expect(screen.getByText(`1/${outreachTemplates.length} channels ready`)).toBeDefined();
+
+    // Switch to second template and copy
+    const secondTemplate = outreachTemplates[1];
+    await user.click(screen.getByRole('button', { name: new RegExp(secondTemplate.channelName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) }));
+    await user.click(screen.getByText('Copy to clipboard'));
+
+    expect(screen.getByText(`2/${outreachTemplates.length} channels ready`)).toBeDefined();
   });
 });

--- a/__tests__/components/OutreachWorkspace.test.tsx
+++ b/__tests__/components/OutreachWorkspace.test.tsx
@@ -102,7 +102,7 @@ describe('OutreachWorkspace', () => {
 
     await user.click(screen.getByText('Copy to clipboard'));
     // Wait for "Copied!" to revert back to "Copy to clipboard"
-    act(() => { vi.advanceTimersByTime(2000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
     await user.click(screen.getByText('Copy to clipboard'));
 
     expect(screen.getByText(`1/${outreachTemplates.length} channels ready`)).toBeDefined();

--- a/__tests__/components/ThemeToggle.test.tsx
+++ b/__tests__/components/ThemeToggle.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '../../src/components/ThemeProvider';
+import ThemeToggle from '../../src/components/ThemeToggle';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    clear: () => { store = {}; },
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+})();
+
+beforeEach(() => {
+  localStorageMock.clear();
+  Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+  document.documentElement.removeAttribute('data-theme');
+});
+
+function renderWithProvider() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeToggle', () => {
+  it('renders with dark mode by default', () => {
+    renderWithProvider();
+    expect(screen.getByLabelText('Switch to light mode')).toBeDefined();
+  });
+
+  it('toggles to light mode on click', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByLabelText('Switch to light mode'));
+
+    expect(screen.getByLabelText('Switch to dark mode')).toBeDefined();
+  });
+
+  it('toggles back to dark mode on second click', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByLabelText('Switch to light mode'));
+    await user.click(screen.getByLabelText('Switch to dark mode'));
+
+    expect(screen.getByLabelText('Switch to light mode')).toBeDefined();
+  });
+
+  it('persists theme to localStorage on toggle', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByLabelText('Switch to light mode'));
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('theme', 'light');
+  });
+
+  it('sets data-theme attribute on document element', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByLabelText('Switch to light mode'));
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('reads stored theme from localStorage on mount', () => {
+    localStorageMock.setItem('theme', 'light');
+    renderWithProvider();
+
+    // After useEffect runs, it should pick up the stored 'light' theme
+    expect(screen.getByLabelText('Switch to dark mode')).toBeDefined();
+  });
+
+  it('ignores invalid localStorage values', () => {
+    localStorageMock.setItem('theme', 'invalid-value');
+    renderWithProvider();
+
+    // Should remain on default dark theme
+    expect(screen.getByLabelText('Switch to light mode')).toBeDefined();
+  });
+
+  it('handles missing localStorage gracefully (default dark)', () => {
+    // localStorage has no 'theme' key
+    renderWithProvider();
+    expect(screen.getByLabelText('Switch to light mode')).toBeDefined();
+  });
+});
+
+describe('ThemeProvider', () => {
+  it('renders children', () => {
+    render(
+      <ThemeProvider>
+        <div data-testid="child">Hello</div>
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('child')).toBeDefined();
+    expect(screen.getByText('Hello')).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -10,7 +11,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': './src',
+      '@': path.resolve(__dirname, './src'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add test files for `ChannelList`, `OutreachEditor`, `ExportPanel`, `OutreachWorkspace`, and `ThemeToggle`
- Cover filtering, sorting, clipboard copy, state management, progress tracking, template switching, localStorage persistence, and edge cases (empty lists, missing data)
- Fix vitest `@` alias to use absolute path for reliable module resolution

Closes #79

## Test plan
- [x] All 125 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive UI tests covering channel list filtering/sorting and empty states, export panel copy/download flows and filename handling, outreach editor character limits, copy/reset/done flows and tips visibility, workspace template switching and progress tracking, and theme toggle persistence and UI updates.
* **Chores**
  * Improved test configuration for more reliable module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->