### PR TITLE
fix: guard localStorage/sessionStorage access for SSR safety

### DIFF
--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -56,6 +56,7 @@ function ResultsContent() {
       }
 
       // Fallback: load from sessionStorage (backward compat)
+      if (typeof window === 'undefined') return;
       const raw = sessionStorage.getItem('projectInput');
       if (!raw) {
         router.push('/launch');

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -17,6 +17,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>('dark');
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const stored = localStorage.getItem('theme') as Theme | null;
     if (stored === 'light' || stored === 'dark') {
       setTheme(stored);
@@ -27,8 +28,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   function toggleTheme() {
     const next = theme === 'dark' ? 'light' : 'dark';
     setTheme(next);
-    localStorage.setItem('theme', next);
-    document.documentElement.setAttribute('data-theme', next);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', next);
+      document.documentElement.setAttribute('data-theme', next);
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Add `typeof window !== 'undefined'` guards before `localStorage` access in `ThemeProvider.tsx` (both the initial read in `useEffect` and the write in `toggleTheme`)
- Add `typeof window === 'undefined'` early return before `sessionStorage` access in `results/page.tsx`

Closes #85

## Test plan
- [x] All 129 existing tests pass
- [x] No lint errors
- [ ] Verify no hydration mismatch in browser (ThemeProvider initializes with `'dark'` default during SSR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding environment detection to prevent runtime errors in server-side rendering scenarios. Theme and storage functionality now properly handle both browser and server execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->