### PR TITLE
fix: eliminate magic string channel matching with channel metadata

### DIFF
--- a/__tests__/channels.test.ts
+++ b/__tests__/channels.test.ts
@@ -24,6 +24,39 @@ describe('channels', () => {
     });
   });
 
+  it('all channels have a valid audience', () => {
+    const validAudiences = ['developer', 'product', 'general'];
+    channels.forEach(ch => {
+      expect(validAudiences).toContain(ch.audience);
+    });
+  });
+
+  it('all channels have a valid outreachType', () => {
+    const validOutreachTypes = [
+      'reddit', 'hackernews', 'producthunt', 'twitter',
+      'linkedin', 'email', 'community', 'devto', 'indiehackers',
+    ];
+    channels.forEach(ch => {
+      expect(validOutreachTypes).toContain(ch.outreachType);
+    });
+  });
+
+  it('developer channels include expected entries', () => {
+    const devChannels = channels.filter(ch => ch.audience === 'developer');
+    const devNames = devChannels.map(ch => ch.name);
+    expect(devNames).toContain('Hacker News (Show HN)');
+    expect(devNames).toContain('GitHub Trending');
+    expect(devNames).toContain('Dev.to');
+  });
+
+  it('product channels include expected entries', () => {
+    const productChannels = channels.filter(ch => ch.audience === 'product');
+    const productNames = productChannels.map(ch => ch.name);
+    expect(productNames).toContain('Product Hunt');
+    expect(productNames).toContain('BetaList');
+    expect(productNames).toContain('Uneed');
+  });
+
   it('includes Dev.to channel', () => {
     const devto = channels.find(ch => ch.name === 'Dev.to');
     expect(devto).toBeDefined();

--- a/src/lib/channels.ts
+++ b/src/lib/channels.ts
@@ -4,6 +4,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Reddit r/SideProject',
     type: 'community',
+    audience: 'general',
+    outreachType: 'reddit',
     url: 'https://www.reddit.com/r/SideProject/',
     description: 'Community for sharing and getting feedback on side projects.',
     audienceSize: '200k+ members',
@@ -13,6 +15,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Reddit r/startups',
     type: 'community',
+    audience: 'general',
+    outreachType: 'reddit',
     url: 'https://www.reddit.com/r/startups/',
     description: 'Startup-focused community for founders sharing progress and seeking advice.',
     audienceSize: '1.2M+ members',
@@ -22,6 +26,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Reddit r/indiehackers',
     type: 'community',
+    audience: 'general',
+    outreachType: 'reddit',
     url: 'https://www.reddit.com/r/indiehackers/',
     description: 'Subreddit for indie hackers building profitable online businesses.',
     audienceSize: '50k+ members',
@@ -31,6 +37,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Reddit r/webdev',
     type: 'community',
+    audience: 'developer',
+    outreachType: 'reddit',
     url: 'https://www.reddit.com/r/webdev/',
     description: 'Web development community for sharing projects and tools.',
     audienceSize: '2M+ members',
@@ -40,6 +48,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Hacker News (Show HN)',
     type: 'news',
+    audience: 'developer',
+    outreachType: 'hackernews',
     url: 'https://news.ycombinator.com/showhn.html',
     description: 'Show HN is for sharing your own work. Tech-savvy audience with high-quality discussion.',
     audienceSize: '10M+ monthly visitors',
@@ -49,6 +59,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Product Hunt',
     type: 'directory',
+    audience: 'product',
+    outreachType: 'producthunt',
     url: 'https://www.producthunt.com/',
     description: 'The go-to platform for launching new products. Strong community of early adopters.',
     audienceSize: '5M+ monthly visitors',
@@ -58,6 +70,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Indie Hackers',
     type: 'community',
+    audience: 'product',
+    outreachType: 'indiehackers',
     url: 'https://www.indiehackers.com/',
     description: 'Community of founders sharing revenue numbers, strategies, and launch stories.',
     audienceSize: '100k+ members',
@@ -67,6 +81,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Dev.to',
     type: 'community',
+    audience: 'developer',
+    outreachType: 'devto',
     url: 'https://dev.to/',
     description: 'Developer blogging platform. Great for technical write-ups and Show-style posts.',
     audienceSize: '20M+ monthly visitors',
@@ -76,6 +92,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Twitter / X',
     type: 'social',
+    audience: 'general',
+    outreachType: 'twitter',
     url: 'https://twitter.com/',
     description: 'Build in public, share updates, connect with other founders and early adopters.',
     audienceSize: '500M+ users',
@@ -85,6 +103,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'LinkedIn',
     type: 'social',
+    audience: 'general',
+    outreachType: 'linkedin',
     url: 'https://www.linkedin.com/',
     description: 'Professional network. Effective for B2B tools and professional-audience products.',
     audienceSize: '900M+ users',
@@ -94,6 +114,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'BetaList',
     type: 'directory',
+    audience: 'product',
+    outreachType: 'community',
     url: 'https://betalist.com/',
     description: 'Directory for discovering and getting early access to upcoming startups.',
     audienceSize: '60k+ subscribers',
@@ -103,6 +125,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Launching.io',
     type: 'directory',
+    audience: 'product',
+    outreachType: 'community',
     url: 'https://launching.io/',
     description: 'Curated directory to submit and discover new product launches.',
     audienceSize: '10k+ visitors',
@@ -112,6 +136,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Lobste.rs',
     type: 'news',
+    audience: 'developer',
+    outreachType: 'community',
     url: 'https://lobste.rs/',
     description: 'Invite-only link aggregation for computing-related content. High signal-to-noise.',
     audienceSize: '50k+ members',
@@ -121,6 +147,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Hacker Newsletter',
     type: 'email',
+    audience: 'developer',
+    outreachType: 'email',
     url: 'https://hackernewsletter.com/',
     description: 'Weekly curated newsletter of top Hacker News stories. Pitch your project for inclusion.',
     audienceSize: '60k+ subscribers',
@@ -130,6 +158,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Ben\'s Bites',
     type: 'email',
+    audience: 'general',
+    outreachType: 'email',
     url: 'https://bensbites.com/',
     description: 'AI-focused newsletter. Great for AI/ML-related product launches.',
     audienceSize: '100k+ subscribers',
@@ -139,6 +169,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'GitHub Trending',
     type: 'community',
+    audience: 'developer',
+    outreachType: 'community',
     url: 'https://github.com/trending',
     description: 'Open-source projects that gain traction appear on GitHub Trending.',
     audienceSize: '100M+ developers',
@@ -148,6 +180,8 @@ export const CHANNELS: Channel[] = [
   {
     name: 'Uneed',
     type: 'directory',
+    audience: 'product',
+    outreachType: 'community',
     url: 'https://uneed.best/',
     description: 'Free product directory with daily launches. Quick submission process.',
     audienceSize: '20k+ monthly visitors',

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -159,25 +159,11 @@ function getTimelineBonus(channel: Channel, timeline: ProjectInput['timeline']):
 }
 
 function isDeveloperChannel(channel: Channel): boolean {
-  const devChannels = [
-    'Hacker News (Show HN)',
-    'GitHub Trending',
-    'Dev.to',
-    'Reddit r/webdev',
-    'Lobste.rs',
-  ];
-  return devChannels.includes(channel.name);
+  return channel.audience === 'developer';
 }
 
 function isProductChannel(channel: Channel): boolean {
-  const productChannels = [
-    'Product Hunt',
-    'BetaList',
-    'Launching.io',
-    'Uneed',
-    'Indie Hackers',
-  ];
-  return productChannels.includes(channel.name);
+  return channel.audience === 'product';
 }
 
 function generateReason(channel: Channel, input: ProjectInput): string {
@@ -392,16 +378,7 @@ function generateTimeline(input: ProjectInput, topChannels: ChannelRecommendatio
 }
 
 function deriveChannelType(channel: Channel): OutreachTemplate['channelType'] {
-  const name = channel.name.toLowerCase();
-  if (name.includes('reddit')) return 'reddit';
-  if (name.includes('hacker news') || name.includes('show hn')) return 'hackernews';
-  if (name.includes('product hunt')) return 'producthunt';
-  if (name.includes('twitter') || name.includes('x')) return 'twitter';
-  if (name.includes('linkedin')) return 'linkedin';
-  if (name.includes('dev.to')) return 'devto';
-  if (name.includes('indie hacker')) return 'indiehackers';
-  if (channel.type === 'email') return 'email';
-  return 'community';
+  return channel.outreachType;
 }
 
 function deriveChannelId(channel: Channel): string {

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -1,9 +1,13 @@
 import type { OutreachTemplate } from './outreach';
 export type { OutreachTemplate } from './outreach';
 
+export type ChannelAudience = 'developer' | 'product' | 'general';
+
 export interface Channel {
   name: string;
   type: 'social' | 'community' | 'news' | 'directory' | 'email';
+  audience: ChannelAudience;
+  outreachType: OutreachTemplate['channelType'];
   url: string;
   description: string;
   audienceSize: string;


### PR DESCRIPTION
## Summary
- Adds `audience` (`developer` | `product` | `general`) and `outreachType` fields to the `Channel` interface and all channel data in `channels.ts`
- Replaces `isDeveloperChannel`/`isProductChannel` string-list matching with simple `channel.audience` field checks
- Replaces `deriveChannelType` name-based string matching with `channel.outreachType` lookup
- Adds tests verifying all channels have valid `audience` and `outreachType` values

Closes #88

## Test plan
- [x] All 133 existing tests pass (no regressions)
- [x] New tests verify every channel has a valid `audience` and `outreachType`
- [x] New tests verify expected channels are categorized as `developer`/`product`
- [x] Lint passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)