### PR TITLE
docs: add API route documentation and expand CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,12 +55,76 @@ Key files:
 
 ## Adding a New Launch Channel
 
-One of the easiest ways to contribute is adding new launch channels to the database:
+One of the easiest ways to contribute is adding new launch channels to the database.
 
-1. Edit `src/lib/channels.ts`
-2. Add a new channel entry with: name, URL, category, audience description, and matching rules
-3. Add corresponding outreach templates in `src/lib/templates.ts`
-4. Add tests for the new channel matching logic
+### 1. Add the channel definition
+
+Edit `src/lib/channels.ts` and add a new entry to the `CHANNELS` array:
+
+```typescript
+{
+  name: 'My New Channel',
+  type: 'community',          // 'social' | 'community' | 'news' | 'directory' | 'email'
+  url: 'https://example.com/',
+  description: 'Short description of the channel and its audience.',
+  audienceSize: '50k+ members',
+  effort: 'medium',           // 'low' | 'medium' | 'high'
+  cost: 'free',               // 'free' | 'low' | 'medium'
+}
+```
+
+### 2. Update scoring/bonus logic
+
+The recommendation engine scores each channel against the user's project input. Scoring bonuses live in `src/lib/engine.ts`:
+
+- **Category bonuses** (`getCategoryBonus`) -- Maps project categories (`saas`, `devtool`, etc.) to per-channel score adjustments. Add your channel name to the relevant category objects:
+  ```typescript
+  devtool: {
+    'My New Channel': 10,  // +10 bonus for devtool projects
+    // ...
+  },
+  ```
+- **Audience bonuses** (`getAudienceBonus`) -- Same pattern, keyed by target audience (`developers`, `founders`, etc.).
+- **Developer/product channel lists** (`isDeveloperChannel`, `isProductChannel`) -- Add your channel name if it qualifies. This controls the +5 URL bonus.
+
+The `scoreChannel` function starts at 50 and applies all bonuses, clamping the result to 0-100.
+
+### 3. Add outreach templates
+
+Edit `src/lib/templates.ts` and add a new entry to the `outreachTemplates` array:
+
+```typescript
+{
+  id: 'my-new-channel',
+  channelName: 'My New Channel',
+  channelType: 'community',   // matches the OutreachTemplate['channelType'] union
+  subject: '{{projectName}} -- {{description}}',
+  body: `Your template here. Use {{projectName}}, {{description}}, and {{demoUrl}} as placeholders.`,
+  tips: [
+    'DO: ...',
+    "DON'T: ...",
+  ],
+}
+```
+
+Available placeholders: `{{projectName}}`, `{{description}}`, `{{demoUrl}}`. All values are HTML-escaped before substitution.
+
+### 4. Add action items (optional)
+
+If your channel needs specific launch steps, add a `case` to the `generateActionItems` switch in `src/lib/engine.ts`:
+
+```typescript
+case 'My New Channel':
+  items.push('Step-by-step action for launching on this channel');
+  break;
+```
+
+### 5. Write tests
+
+Add tests in `__tests__/` to verify:
+- The channel appears in recommendations for matching project inputs
+- The scoring bonuses produce expected scores
+- The outreach template fills correctly
 
 ## Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,111 @@ src/
 __tests__/       Test files
 ```
 
+## API Reference
+
+### `GET /api/health`
+
+Health check endpoint.
+
+**Response** `200`
+```json
+{ "status": "ok", "timestamp": "2025-01-15T12:00:00.000Z" }
+```
+
+---
+
+### `POST /api/plans`
+
+Create a new launch plan. Validates input with Zod, scores channels, and returns a full plan.
+
+**Request body**
+
+| Field            | Type     | Required | Notes |
+|------------------|----------|----------|-------|
+| `projectName`    | `string` | Yes      | 1-100 chars |
+| `description`    | `string` | Yes      | 1-200 chars |
+| `repoUrl`        | `string` | No       | Must be `https://` URL (or empty string) |
+| `demoUrl`        | `string` | No       | Must be `https://` URL (or empty string) |
+| `targetAudience` | `string` | No       | `developers` \| `designers` \| `marketers` \| `founders` \| `general` |
+| `category`       | `string` | No       | `saas` \| `devtool` \| `mobile-app` \| `marketplace` \| `content` \| `other` |
+| `budget`         | `string` | No       | `zero` \| `low` \| `medium` |
+| `timeline`       | `string` | No       | `rush` \| `standard` \| `relaxed` |
+
+**Response** `201`
+```json
+{
+  "id": "uuid",
+  "input": { "projectName": "...", "description": "...", ... },
+  "channels": ["Reddit r/SideProject", "Hacker News (Show HN)", ...],
+  "recommendations": {
+    "projectName": "...",
+    "channels": [{ "channel": { ... }, "relevanceScore": 82, "reason": "...", "actionItems": [...] }],
+    "timeline": [{ "day": 1, "title": "Preparation", "tasks": [...] }],
+    "outreachTemplates": [{ "id": "...", "channelName": "...", "body": "..." }]
+  },
+  "createdAt": "2025-01-15T12:00:00.000Z",
+  "updatedAt": "2025-01-15T12:00:00.000Z"
+}
+```
+
+**Error responses**
+
+| Status | Body | When |
+|--------|------|------|
+| `400`  | `{ "error": "Invalid JSON in request body" }` | Malformed JSON |
+| `400`  | `{ "error": "Validation failed", "details": [{ "field": "projectName", "message": "..." }] }` | Zod validation failure |
+
+---
+
+### `GET /api/plans`
+
+List all plans.
+
+**Response** `200` -- Array of plan objects (same shape as the `POST` response).
+
+---
+
+### `GET /api/plans/:id`
+
+Get a single plan by ID.
+
+**Response** `200` -- Plan object.
+
+| Status | Body | When |
+|--------|------|------|
+| `404`  | `{ "error": "Plan not found" }` | No plan with that ID |
+
+---
+
+### `PUT /api/plans/:id`
+
+Update an existing plan. Accepts a partial body (any subset of the `POST` fields).
+
+**Response** `200` -- Updated plan object.
+
+| Status | Body | When |
+|--------|------|------|
+| `400`  | `{ "error": "Invalid JSON" }` | Malformed JSON |
+| `400`  | `{ "error": "Validation failed", "details": [...] }` | Zod validation failure |
+| `404`  | `{ "error": "Plan not found" }` | No plan with that ID |
+
+---
+
+### `DELETE /api/plans/:id`
+
+Delete a plan.
+
+**Response** `200`
+```json
+{ "message": "Plan deleted" }
+```
+
+| Status | Body | When |
+|--------|------|------|
+| `404`  | `{ "error": "Plan not found" }` | No plan with that ID |
+
+---
+
 ## Roadmap
 
 - [x] Core recommendation engine with rules-based matching

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -10,9 +10,19 @@ import { CHANNELS } from './channels';
 
 /**
  * Score a channel based on how well it matches the project input.
- * Returns a value between 0 and 100.
+ *
+ * Starts from a base score of 50 and applies bonuses/penalties for:
+ * - **Category match** — e.g. `devtool` projects score higher on Hacker News
+ * - **Audience match** — e.g. `founders` audience boosts Indie Hackers
+ * - **Budget match** — free channels score higher when budget is `zero`
+ * - **Timeline match** — low-effort channels score higher on `rush` timelines
+ * - **URL bonuses** — +5 for repo URL on dev channels, +5 for demo URL on product channels
+ *
+ * @param channel - The channel to score
+ * @param input - The project input containing user-provided details
+ * @returns A relevance score between 0 and 100
  */
-function scoreChannel(channel: Channel, input: ProjectInput): number {
+export function scoreChannel(channel: Channel, input: ProjectInput): number {
   let score = 50; // base score
 
   // Category matching
@@ -518,6 +528,13 @@ function generateOutreachTemplates(
 /**
  * Generate a complete launch plan with channel recommendations,
  * timeline, and outreach templates based on project input.
+ *
+ * Scores all channels via {@link scoreChannel}, ranks them by relevance,
+ * and selects the top 10. Then generates a 7-day launch timeline and
+ * outreach templates for the top 5 channels.
+ *
+ * @param input - The project input containing name, description, URLs, and optional filters
+ * @returns A complete {@link LaunchPlan} with ranked channels, timeline, and outreach templates
  */
 export function generateRecommendations(input: ProjectInput): LaunchPlan {
   // Score and rank all channels


### PR DESCRIPTION
## Summary
- Add **API Reference** section to README.md documenting all endpoints (`/api/health`, `/api/plans`, `/api/plans/:id`) with request/response examples, validation rules, and error codes
- Expand **CONTRIBUTING.md** with step-by-step guides for adding new channels, updating scoring/bonus logic, adding outreach templates, and writing tests
- Add detailed **JSDoc comments** to `scoreChannel` and `generateRecommendations` in `src/lib/engine.ts`
- Export `scoreChannel` for external consumption

Closes #89

## Test plan
- [x] `pnpm lint` passes with no warnings or errors
- [x] `pnpm test` passes (129/129 tests)
- [ ] Verify README API Reference renders correctly on GitHub
- [ ] Verify CONTRIBUTING.md code examples are accurate

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor guide with detailed step-by-step workflow for adding new launch channels.
  * Added comprehensive API Reference documenting endpoints for health checks and plan management (create, list, retrieve, update, delete) with request/response schemas.
  * Enhanced function documentation with scoring criteria details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->