### PR TITLE
test: add template XSS sanitization and engine scoring edge case tests

### DIFF
--- a/__tests__/engine.test.ts
+++ b/__tests__/engine.test.ts
@@ -56,3 +56,198 @@ describe('generateRecommendations', () => {
     expect(results.outreachTemplates.length).toBeGreaterThan(0);
   });
 });
+
+describe('scoring edge cases', () => {
+  describe('category bonus', () => {
+    it('gives no bonus when category is undefined', () => {
+      const withoutCategory = generateRecommendations({ ...baseInput });
+      const withCategory = generateRecommendations({ ...baseInput, category: 'saas' });
+      // Without category, Product Hunt should score lower since it gets +15 for saas
+      const phWithout = withoutCategory.channels.find((r) => r.channel.name === 'Product Hunt');
+      const phWith = withCategory.channels.find((r) => r.channel.name === 'Product Hunt');
+      expect(phWith!.relevanceScore).toBeGreaterThan(phWithout!.relevanceScore);
+    });
+
+    it('gives no bonus for unrecognized category channel combo', () => {
+      // 'other' category gives 0 to channels not in its map (e.g., Lobste.rs)
+      const results = generateRecommendations({ ...baseInput, category: 'other' });
+      const lobsters = results.channels.find((r) => r.channel.name === 'Lobste.rs');
+      const noCategory = generateRecommendations({ ...baseInput });
+      const lobstersBase = noCategory.channels.find((r) => r.channel.name === 'Lobste.rs');
+      expect(lobsters!.relevanceScore).toBe(lobstersBase!.relevanceScore);
+    });
+  });
+
+  describe('audience bonus', () => {
+    it('gives no bonus when targetAudience is undefined', () => {
+      const without = generateRecommendations({ ...baseInput });
+      const with_ = generateRecommendations({ ...baseInput, targetAudience: 'developers' });
+      const hn = with_.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      const hnBase = without.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      expect(hn!.relevanceScore).toBeGreaterThan(hnBase!.relevanceScore);
+    });
+
+    it('boosts developer channels for developers audience', () => {
+      const results = generateRecommendations({ ...baseInput, targetAudience: 'developers' });
+      const devTo = results.channels.find((r) => r.channel.name === 'Dev.to');
+      expect(devTo!.relevanceScore).toBeGreaterThanOrEqual(60); // base 50 + 10
+    });
+
+    it('boosts founder channels for founders audience', () => {
+      const results = generateRecommendations({ ...baseInput, targetAudience: 'founders' });
+      const ih = results.channels.find((r) => r.channel.name === 'Indie Hackers');
+      expect(ih!.relevanceScore).toBeGreaterThanOrEqual(62); // base 50 + 12
+    });
+  });
+
+  describe('budget bonus', () => {
+    it('penalizes non-free channels when budget is zero', () => {
+      const withZero = generateRecommendations({ ...baseInput, budget: 'zero' });
+      const noBudget = generateRecommendations({ ...baseInput });
+      // Non-free channels get -15, so they should score lower overall
+      // Check that more free channels appear in top results
+      const freeCount = withZero.channels.filter((r) => r.channel.cost === 'free').length;
+      expect(freeCount).toBeGreaterThanOrEqual(8); // most top 10 should be free
+    });
+
+    it('gives bonus to free channels when budget is zero', () => {
+      const withBudget = generateRecommendations({ ...baseInput, budget: 'zero' });
+      const noBudget = generateRecommendations({ ...baseInput });
+      // Free channels get +5 when budget is 'zero'
+      const freeChannel = withBudget.channels.find(
+        (r) => r.channel.cost === 'free',
+      );
+      const sameNobudget = noBudget.channels.find(
+        (r) => r.channel.name === freeChannel!.channel.name,
+      );
+      expect(freeChannel!.relevanceScore).toBeGreaterThan(sameNobudget!.relevanceScore);
+    });
+
+    it('gives no bonus when budget is undefined', () => {
+      const withBudget = generateRecommendations({ ...baseInput, budget: 'zero' });
+      const noBudget = generateRecommendations({ ...baseInput });
+      // With undefined budget, free channels should not get the +5 bonus
+      const blNoBudget = noBudget.channels.find((r) => r.channel.name === 'BetaList');
+      const blWithBudget = withBudget.channels.find((r) => r.channel.name === 'BetaList');
+      expect(blWithBudget!.relevanceScore).toBeGreaterThan(blNoBudget!.relevanceScore);
+    });
+  });
+
+  describe('timeline bonus', () => {
+    it('boosts low-effort channels on rush timeline', () => {
+      const rush = generateRecommendations({ ...baseInput, timeline: 'rush' });
+      const standard = generateRecommendations({ ...baseInput });
+      // BetaList has effort: 'low', should get +10 on rush
+      const blRush = rush.channels.find((r) => r.channel.name === 'BetaList');
+      const blStd = standard.channels.find((r) => r.channel.name === 'BetaList');
+      expect(blRush!.relevanceScore).toBeGreaterThan(blStd!.relevanceScore);
+    });
+
+    it('penalizes high-effort channels on rush timeline', () => {
+      const rush = generateRecommendations({ ...baseInput, timeline: 'rush' });
+      const standard = generateRecommendations({ ...baseInput });
+      // Low-effort channels should rank higher on rush vs standard
+      const lowEffortRushAvg =
+        rush.channels
+          .filter((r) => r.channel.effort === 'low')
+          .reduce((sum, r) => sum + r.relevanceScore, 0) /
+        rush.channels.filter((r) => r.channel.effort === 'low').length;
+      const lowEffortStdAvg =
+        standard.channels
+          .filter((r) => r.channel.effort === 'low')
+          .reduce((sum, r) => sum + r.relevanceScore, 0) /
+        standard.channels.filter((r) => r.channel.effort === 'low').length;
+      expect(lowEffortRushAvg).toBeGreaterThan(lowEffortStdAvg);
+    });
+
+    it('boosts high-effort channels on relaxed timeline', () => {
+      const relaxed = generateRecommendations({ ...baseInput, timeline: 'relaxed' });
+      const standard = generateRecommendations({ ...baseInput });
+      const hnRelaxed = relaxed.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      const hnStd = standard.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      expect(hnRelaxed!.relevanceScore).toBeGreaterThan(hnStd!.relevanceScore);
+    });
+  });
+
+  describe('score clamping', () => {
+    it('scores never exceed 100', () => {
+      // Maximize bonuses: devtool category + developers audience + zero budget (free channels) + relaxed timeline
+      const results = generateRecommendations({
+        ...baseInput,
+        category: 'devtool',
+        targetAudience: 'developers',
+        budget: 'zero',
+        timeline: 'relaxed',
+      });
+      results.channels.forEach((r) => {
+        expect(r.relevanceScore).toBeLessThanOrEqual(100);
+      });
+    });
+
+    it('scores never go below 0', () => {
+      // Minimize bonuses: zero budget penalizes non-free, rush penalizes high-effort
+      const results = generateRecommendations({
+        ...baseInput,
+        category: 'other',
+        budget: 'zero',
+        timeline: 'rush',
+      });
+      results.channels.forEach((r) => {
+        expect(r.relevanceScore).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    it('all scores are integers or valid numbers', () => {
+      const results = generateRecommendations({
+        ...baseInput,
+        category: 'saas',
+        targetAudience: 'founders',
+        budget: 'low',
+        timeline: 'standard',
+      });
+      results.channels.forEach((r) => {
+        expect(Number.isFinite(r.relevanceScore)).toBe(true);
+      });
+    });
+  });
+
+  describe('URL bonuses', () => {
+    it('gives bonus to developer channels when repoUrl is provided', () => {
+      const withRepo = generateRecommendations({ ...baseInput });
+      const withoutRepo = generateRecommendations({
+        ...baseInput,
+        repoUrl: '',
+      });
+      const hnWith = withRepo.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      const hnWithout = withoutRepo.channels.find((r) => r.channel.name === 'Hacker News (Show HN)');
+      expect(hnWith!.relevanceScore).toBeGreaterThan(hnWithout!.relevanceScore);
+    });
+
+    it('gives bonus to product channels when demoUrl is provided', () => {
+      const withDemo = generateRecommendations({ ...baseInput });
+      const withoutDemo = generateRecommendations({
+        ...baseInput,
+        demoUrl: '',
+      });
+      const phWith = withDemo.channels.find((r) => r.channel.name === 'Product Hunt');
+      const phWithout = withoutDemo.channels.find((r) => r.channel.name === 'Product Hunt');
+      expect(phWith!.relevanceScore).toBeGreaterThan(phWithout!.relevanceScore);
+    });
+  });
+
+  describe('all-zero bonuses (minimal input)', () => {
+    it('returns base score of 50 for channels with no matching bonuses', () => {
+      // No optional fields → all bonus functions return 0, no URLs → no URL bonuses
+      const results = generateRecommendations({
+        projectName: 'X',
+        description: 'Y',
+        repoUrl: '',
+        demoUrl: '',
+      });
+      // All channels should have the base score of 50 since no bonuses apply
+      results.channels.forEach((r) => {
+        expect(r.relevanceScore).toBe(50);
+      });
+    });
+  });
+});

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { fillTemplate, outreachTemplates } from '../src/lib/templates';
+import type { OutreachTemplate } from '../src/types/outreach';
+
+const baseTemplate: OutreachTemplate = {
+  id: 'test-template',
+  channelName: 'Test Channel',
+  channelType: 'community',
+  subject: 'Launch: {{projectName}} - {{description}}',
+  body: 'Check out {{projectName}}: {{description}} at {{demoUrl}}',
+  tips: ['Be nice'],
+};
+
+const baseValues = {
+  projectName: 'MyApp',
+  description: 'A cool tool',
+  demoUrl: 'https://example.com',
+};
+
+describe('fillTemplate', () => {
+  describe('basic substitution', () => {
+    it('replaces all placeholders in subject and body', () => {
+      const result = fillTemplate(baseTemplate, baseValues);
+      expect(result.subject).toBe('Launch: MyApp - A cool tool');
+      expect(result.body).toBe('Check out MyApp: A cool tool at https://example.com');
+    });
+
+    it('replaces multiple occurrences of the same placeholder', () => {
+      const template: OutreachTemplate = {
+        ...baseTemplate,
+        body: '{{projectName}} is great. Try {{projectName}} today!',
+      };
+      const result = fillTemplate(template, baseValues);
+      expect(result.body).toBe('MyApp is great. Try MyApp today!');
+    });
+
+    it('handles template with no subject', () => {
+      const template: OutreachTemplate = {
+        ...baseTemplate,
+        subject: undefined,
+      };
+      const result = fillTemplate(template, baseValues);
+      expect(result.subject).toBeUndefined();
+      expect(result.body).toContain('MyApp');
+    });
+
+    it('preserves non-placeholder text', () => {
+      const template: OutreachTemplate = {
+        ...baseTemplate,
+        body: 'Hello world, no placeholders here.',
+      };
+      const result = fillTemplate(template, baseValues);
+      expect(result.body).toBe('Hello world, no placeholders here.');
+    });
+
+    it('preserves other template properties', () => {
+      const result = fillTemplate(baseTemplate, baseValues);
+      expect(result.id).toBe('test-template');
+      expect(result.channelName).toBe('Test Channel');
+      expect(result.channelType).toBe('community');
+      expect(result.tips).toEqual(['Be nice']);
+    });
+  });
+
+  describe('XSS sanitization', () => {
+    it('escapes HTML tags in projectName', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: '<script>alert("xss")</script>',
+      });
+      expect(result.body).not.toContain('<script>');
+      expect(result.body).toContain('&lt;script&gt;');
+    });
+
+    it('escapes HTML tags in description', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        description: '<img src=x onerror=alert(1)>',
+      });
+      expect(result.body).not.toContain('<img');
+      expect(result.body).toContain('&lt;img');
+    });
+
+    it('escapes HTML tags in demoUrl', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        demoUrl: 'javascript:alert("xss")',
+      });
+      expect(result.body).toContain('javascript:alert(&quot;xss&quot;)');
+    });
+
+    it('escapes ampersands', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: 'A&B',
+      });
+      expect(result.body).toContain('A&amp;B');
+    });
+
+    it('escapes single quotes', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: "it's",
+      });
+      expect(result.body).toContain('it&#x27;s');
+    });
+
+    it('escapes double quotes', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: 'say "hello"',
+      });
+      expect(result.body).toContain('say &quot;hello&quot;');
+    });
+
+    it('escapes all HTML entities together', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: `<b>"Tom & Jerry's"</b>`,
+      });
+      expect(result.body).toContain(
+        '&lt;b&gt;&quot;Tom &amp; Jerry&#x27;s&quot;&lt;/b&gt;',
+      );
+    });
+
+    it('handles nested script injection attempts', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: '<<script>script>alert("xss")<</script>/script>',
+      });
+      expect(result.body).not.toContain('<script>');
+      expect(result.subject).not.toContain('<script>');
+    });
+
+    it('escapes quotes to prevent attribute injection', () => {
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        description: '" onmouseover="alert(1)" data-x="',
+      });
+      // Quotes are escaped so they can't break out of HTML attributes
+      expect(result.body).not.toContain('"');
+      expect(result.body).toContain('&quot; onmouseover=&quot;alert(1)&quot; data-x=&quot;');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string values', () => {
+      const result = fillTemplate(baseTemplate, {
+        projectName: '',
+        description: '',
+        demoUrl: '',
+      });
+      expect(result.body).toBe('Check out :  at ');
+    });
+
+    it('handles values with only special characters', () => {
+      const result = fillTemplate(baseTemplate, {
+        projectName: '<>&"\'',
+        description: '<>&"\'',
+        demoUrl: '<>&"\'',
+      });
+      expect(result.body).not.toContain('<');
+      expect(result.body).not.toContain('>');
+    });
+
+    it('handles very long input strings', () => {
+      const longString = 'a'.repeat(10000);
+      const result = fillTemplate(baseTemplate, {
+        ...baseValues,
+        projectName: longString,
+      });
+      expect(result.body).toContain(longString);
+    });
+  });
+});
+
+describe('outreachTemplates', () => {
+  it('exports a non-empty array of templates', () => {
+    expect(outreachTemplates.length).toBeGreaterThan(0);
+  });
+
+  it('each template has required fields', () => {
+    for (const t of outreachTemplates) {
+      expect(t.id).toBeTruthy();
+      expect(t.channelName).toBeTruthy();
+      expect(t.channelType).toBeTruthy();
+      expect(t.body).toBeTruthy();
+      expect(t.tips.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('each template has unique id', () => {
+    const ids = outreachTemplates.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Create `__tests__/templates.test.ts` with XSS payload tests, HTML entity escaping, and edge cases for `fillTemplate`/`escapeHtml`
- Add edge case tests to `__tests__/engine.test.ts` for each bonus function (`getCategoryBonus`, `getAudienceBonus`, `getBudgetBonus`, `getTimelineBonus`)
- Test score boundary clamping (min 0, max 100), URL bonuses, and all-zero bonus scenarios

Closes #86

## Test plan
- [x] All 166 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Template tests cover: basic substitution, XSS payloads (`<script>`, `<img onerror>`, nested injection), all 5 HTML entities (`&`, `<`, `>`, `"`, `'`), empty strings, long inputs
- [x] Engine tests cover: category/audience/budget/timeline bonuses with and without values, score clamping 0-100, URL bonuses, minimal input base scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)